### PR TITLE
resolves 313 enchances Aqua Xeno, Hammerpede and Protomorph AI

### DIFF
--- a/src/main/java/com/arisux/avp/EntityHandler.java
+++ b/src/main/java/com/arisux/avp/EntityHandler.java
@@ -174,7 +174,8 @@ public class EntityHandler implements IInitializable
 				BiomeGenBase.roofedForest,
 				BiomeGenBase.swampland,
 				BiomeGenBase.taiga,
-				BiomeGenBase.taigaHills
+				BiomeGenBase.taigaHills,
+				BiomeLVBase.acheron
 		};
 		
 		BiomeGenBase[] predatorBiomes = new BiomeGenBase[] 
@@ -195,32 +196,41 @@ public class EntityHandler implements IInitializable
 				BiomeGenBase.jungleEdge,
 				BiomeGenBase.jungleHills,
 				BiomeGenBase.taiga,
-				BiomeGenBase.taigaHills
+				BiomeGenBase.taigaHills,
+				BiomeLVBase.varda
+		};
+		
+		BiomeGenBase[] engineerBiomes = new BiomeGenBase[] 
+		{
+				BiomeLVBase.varda,
+				BiomeLVBase.acheron
 		};
 
-		EntityRegistry.addSpawn(EntityDrone.class, 56, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
-		EntityRegistry.addSpawn(EntityWarrior.class, 38, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
-		EntityRegistry.addSpawn(EntityPraetorian.class, 14, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
-		EntityRegistry.addSpawn(EntityFacehugger.class, 24, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
-		EntityRegistry.addSpawn(EntityChestburster.class, 12, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
-		EntityRegistry.addSpawn(EntityYautja.class, 19, 1, 3, EnumCreatureType.monster, predatorBiomes);
-		EntityRegistry.addSpawn(EntityYautjaBerserker.class, 6, 1, 3, EnumCreatureType.monster, predatorBiomes);
-		EntityRegistry.addSpawn(EntityMarine.class, 16, 1, 2, EnumCreatureType.creature, new BiomeGenBase[] { 
+		EntityRegistry.addSpawn(EntityDrone.class, 50, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
+		EntityRegistry.addSpawn(EntityWarrior.class, 25, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
+		EntityRegistry.addSpawn(EntityPraetorian.class, 10, 1, 2, EnumCreatureType.monster, xenomorphBiomes);
+		EntityRegistry.addSpawn(EntityFacehugger.class, 5, 1, 2, EnumCreatureType.monster, xenomorphBiomes);
+		EntityRegistry.addSpawn(EntityChestburster.class, 10, 1, 3, EnumCreatureType.monster, xenomorphBiomes);
+		EntityRegistry.addSpawn(EntityYautja.class, 2, 1, 1, EnumCreatureType.monster, predatorBiomes);
+		EntityRegistry.addSpawn(EntityYautjaBerserker.class, 1, 1, 1, EnumCreatureType.monster, predatorBiomes);
+		EntityRegistry.addSpawn(EntityMarine.class, 2, 1, 1, EnumCreatureType.creature, new BiomeGenBase[] { 
 			BiomeGenBase.swampland, 
 			BiomeGenBase.forest, 
 			BiomeGenBase.forestHills, 
 			BiomeGenBase.taiga, 
 			BiomeGenBase.taigaHills, 
-			BiomeGenBase.plains 
+			BiomeGenBase.plains
 		});
-		EntityRegistry.addSpawn(EntityProtomorph.class, 4, 1, 1, EnumCreatureType.monster, new BiomeGenBase[] { 
+		EntityRegistry.addSpawn(EntityProtomorph.class, 25, 1, 2, EnumCreatureType.monster, new BiomeGenBase[] { 
 			BiomeLVBase.varda
 		});
-		EntityRegistry.addSpawn(EntityHammerpede.class, 6, 1, 2, EnumCreatureType.monster, new BiomeGenBase[] { 
+		EntityRegistry.addSpawn(EntityHammerpede.class, 50, 1, 3, EnumCreatureType.monster, new BiomeGenBase[] { 
 			BiomeLVBase.varda
 		});
-		EntityRegistry.addSpawn(EntityTrilobite.class, 6, 1, 2, EnumCreatureType.monster, new BiomeGenBase[] { 
+		EntityRegistry.addSpawn(EntityTrilobite.class, 1, 1, 1, EnumCreatureType.monster, new BiomeGenBase[] { 
 			BiomeLVBase.varda
 		});
+		EntityRegistry.addSpawn(EntityEngineer.class, 2, 1, 1, EnumCreatureType.monster, engineerBiomes);
+		EntityRegistry.addSpawn(EntitySpaceJockey.class, 1, 1, 1, EnumCreatureType.monster, engineerBiomes);
 	}
 }

--- a/src/main/java/com/arisux/avp/entities/mob/EntityAqua.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityAqua.java
@@ -13,6 +13,8 @@ public class EntityAqua extends EntityXenomorph
 		this.jumpMovementFactor = 0.2F;
 		this.experienceValue = 100;
 		this.setSize(1F, 3F);
+		this.getNavigator().setCanSwim(true);
+		this.getNavigator().setAvoidsWater(false);
 	}
 
 	@Override
@@ -40,6 +42,12 @@ public class EntityAqua extends EntityXenomorph
 	protected String getLivingSound()
 	{
 		return AliensVsPredator.properties().SOUND_ALIEN_LIVING;
+	}
+	
+	@Override
+	public boolean canBreatheUnderwater()
+	{
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/arisux/avp/entities/mob/EntityHammerpede.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityHammerpede.java
@@ -15,6 +15,7 @@ import net.minecraft.entity.ai.EntityAIAttackOnCollide;
 import net.minecraft.entity.ai.EntityAIHurtByTarget;
 import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
 import net.minecraft.entity.monster.IMob;
+import com.arisux.avp.entities.EntityAcidPool;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
@@ -28,7 +29,7 @@ public class EntityHammerpede extends EntitySpeciesAlien implements IMob
 		@Override
 		public boolean isEntityApplicable(Entity entity)
 		{
-			return !(entity instanceof EntitySpeciesAlien) && !(entity instanceof EntityHammerpede);
+			return !(entity instanceof EntitySpeciesAlien) && !(entity instanceof EntityHammerpede) && !(entity instanceof EntityAcidPool);
 		}
 	};
 	
@@ -36,7 +37,7 @@ public class EntityHammerpede extends EntitySpeciesAlien implements IMob
 	{
 		super(par1World);
 
-		this.setSize(1.0F, 0.2F);
+		this.setSize(0.5F, 0.5F);
 		this.experienceValue = 16;
 		this.getNavigator().setCanSwim(true);
 		this.getNavigator().setAvoidsWater(false);

--- a/src/main/java/com/arisux/avp/entities/mob/EntityProtomorph.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityProtomorph.java
@@ -15,6 +15,8 @@ public class EntityProtomorph extends EntityXenomorph
 		this.jumpMovementFactor = 0.02F;
 		this.experienceValue = 100;
 		this.setSize(0.8F, 1.8F);
+		this.getNavigator().setCanSwim(true);
+		this.getNavigator().setAvoidsWater(true);
 		this.canClimb = false;
 		this.isDependant = false;
 	}


### PR DESCRIPTION
resolved 313 to allow Aqua Xeno to breathe underwater and swim.  prevented hammerpede from attacking AcidPool and pushing it around.  made hammerpede hit box more uniform so that it can be hit with melee weapons and guns.  stopped Protomorph from drowning and/or falling into water while pursuing player or mobs.  added engineer biome group spawn list.  allow Yautja to rarely spawn on LV-223.  source for spawn information: avp.wikia.com.  verified desired behaviors in creative mode and single-player