### PR TITLE
fall damage and targetting cleanup

### DIFF
--- a/src/main/java/com/arisux/avp/BlockHandler.java
+++ b/src/main/java/com/arisux/avp/BlockHandler.java
@@ -44,7 +44,7 @@ import net.minecraft.creativetab.CreativeTabs;
 
 public class BlockHandler extends IBHandler implements IInitializable
 {
-	public Block terrainHiveResin = (new BlockHiveResin(Material.wood)).setHardness(0.1F).setLightOpacity(255),
+	public Block terrainHiveResin = (new BlockHiveResin(Material.wood)).setHardness(5F).setResistance(10.0F).setLightOpacity(255),
 		blockOvamorph = (new HookedBlock(Material.rock)),
 		blockShipMetal1 = (new HookedBlock(Material.iron).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
 		blockShipMetal2 = (new HookedBlock(Material.iron).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
@@ -58,7 +58,7 @@ public class BlockHandler extends IBHandler implements IInitializable
 		blockShipDecor6 = (new HookedBlock(Material.iron).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
 		blockSacrificialSpawner = (new BlockTempleSpawner(Material.rock, false)),
 		blockSpawnerCreative = (new BlockTempleSpawner(Material.rock, true)),
-		blockHiveNode = (new BlockHiveNode(Material.rock).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
+		blockHiveNode = (new BlockHiveNode(Material.rock).setHardness(5F).setResistance(10.0F).setLightOpacity(255)),
 		blockRelicTile = (new HookedBlock(Material.rock).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
 		blockTempleBrick = (new HookedBlock(Material.rock).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
 		blockTempleTile = (new HookedBlock(Material.rock).setHardness(5F).setResistance(30.0F).setLightOpacity(255)),
@@ -117,10 +117,10 @@ public class BlockHandler extends IBHandler implements IInitializable
 		blockNegativeTransformer = (new BlockNegativeTransformer(Material.iron)).setHardness(3.2F).setResistance(2.6F),
 		blockSupplies = (new BlockSupplies(Material.iron)),
 		blockSolarPanel = (new BlockSolarPanel(Material.iron)).setHardness(3.2F).setResistance(2.6F),
-		oreSilicon = (new HookedBlock(Material.rock)).setHardness(2.2F).setResistance(1.4F),
-		oreLithium = (new HookedBlock(Material.iron)).setHardness(4.2F).setResistance(5.4F),
-		oreCopper = (new HookedBlock(Material.iron)).setHardness(3.2F).setResistance(2.6F),
-		oreBauxite = (new HookedBlock(Material.iron)).setHardness(3.2F).setResistance(2.6F),
+		oreSilicon = (new HookedBlock(Material.rock)).setHardness(2.2F).setResistance(1.4F).setLightOpacity(255),
+		oreLithium = (new HookedBlock(Material.iron)).setHardness(4.2F).setResistance(5.4F).setLightOpacity(255),
+		oreCopper = (new HookedBlock(Material.iron)).setHardness(3.2F).setResistance(2.6F).setLightOpacity(255),
+		oreBauxite = (new HookedBlock(Material.iron)).setHardness(3.2F).setResistance(2.6F).setLightOpacity(255),
 		mainframePanelShimmer = (new HookedBlock(Material.iron).setIconSet(new IconSet("avp:mainframe_shimmer")).setHardness(3F).setResistance(1F).setLightLevel(0.5F)),
 		mainframePanelFlicker = (new HookedBlock(Material.iron).setIconSet(new IconSet("avp:mainframe_flicker")).setHardness(3F).setResistance(1F).setLightLevel(0.5F)),
 		blockVent0 = (new HookedBlock(Material.iron)).setOpaque(false).setHardness(5F).setResistance(30.0F).setLightOpacity(0),

--- a/src/main/java/com/arisux/avp/entities/ai/alien/EntitySelectorXenomorph.java
+++ b/src/main/java/com/arisux/avp/entities/ai/alien/EntitySelectorXenomorph.java
@@ -1,6 +1,7 @@
 package com.arisux.avp.entities.ai.alien;
 
 import com.arisux.avp.entities.mob.EntitySpeciesAlien;
+import com.arisux.avp.entities.EntityAcidPool;
 
 import net.minecraft.command.IEntitySelector;
 import net.minecraft.entity.Entity;
@@ -12,6 +13,6 @@ public class EntitySelectorXenomorph implements IEntitySelector
     @Override
     public boolean isEntityApplicable(Entity entity)
     {
-        return !(entity instanceof EntitySpeciesAlien);
+        return !(entity instanceof EntitySpeciesAlien) && !(entity instanceof EntityAcidPool);
     }
 }

--- a/src/main/java/com/arisux/avp/entities/mob/EntityAqua.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityAqua.java
@@ -11,12 +11,6 @@ import net.minecraft.entity.ai.EntityAIWander;
 import net.minecraft.entity.ai.EntityAIHurtByTarget;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.monster.EntityWitch;
-import net.minecraft.entity.monster.EntitySpider;
-import net.minecraft.entity.monster.EntityCreeper;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.passive.EntityAnimal;
-import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.world.World;
 
 public class EntityAqua extends EntityXenomorph
@@ -32,16 +26,8 @@ public class EntityAqua extends EntityXenomorph
 		this.tasks.addTask(0, new EntityAISwimming(this));
 		this.tasks.addTask(1, new EntityAIAttackOnCollide(this, 0.800000011920929D, true));
 		this.tasks.addTask(1, new EntityAIWander(this, 0.800000011920929D));
-		this.targetTasks.addTask(1, new EntityAILeapAtTarget(this, 0.8F));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesYautja.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesEngineer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityMarine.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityPlayer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityVillager.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityAnimal.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityWitch.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpider.class, 0, true));
-		this.targetTasks.addTask(3, new EntityAIHurtByTarget(this, true));
+		this.targetTasks.addTask(1, new EntityAILeapAtTarget(this, 0.4F));
+		this.targetTasks.addTask(2, new EntityAIHurtByTarget(this, true));
 	}
 
 	@Override

--- a/src/main/java/com/arisux/avp/entities/mob/EntityFacehugger.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityFacehugger.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import com.arisux.airi.lib.WorldUtil;
 import com.arisux.avp.AliensVsPredator;
 import com.arisux.avp.entities.extended.ExtendedEntityLivingBase;
+import com.arisux.avp.entities.ai.alien.EntitySelectorXenomorph;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -17,12 +18,7 @@ import net.minecraft.entity.ai.EntityAISwimming;
 import net.minecraft.entity.ai.EntityAIWander;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.monster.EntityWitch;
-import net.minecraft.entity.monster.EntitySpider;
-import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.passive.EntityAnimal;
-import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
@@ -39,7 +35,7 @@ public class EntityFacehugger extends EntitySpeciesAlien implements IMob
 	{
 		super(world);
 		this.isFertile = true;
-		this.setSize(0.9F, 0.9F);
+		this.setSize(0.8F, 0.8F);
 		this.experienceValue = 10;
 		this.getNavigator().setCanSwim(true);
 		this.getNavigator().setAvoidsWater(true);
@@ -47,15 +43,7 @@ public class EntityFacehugger extends EntitySpeciesAlien implements IMob
 		this.tasks.addTask(1, new EntityAIAttackOnCollide(this, 0.800000011920929D, true));
 		this.tasks.addTask(1, new EntityAIWander(this, 0.800000011920929D));
 		this.targetTasks.addTask(1, new EntityAILeapAtTarget(this, 0.8F));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesYautja.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesEngineer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityMarine.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityPlayer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityVillager.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityAnimal.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityCreeper.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityWitch.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpider.class, 0, true));
+		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, Entity.class, /** targetChance **/0, /** shouldCheckSight **/false, /** nearbyOnly **/false, EntitySelectorXenomorph.instance));
 	}
 
 	@Override
@@ -66,13 +54,15 @@ public class EntityFacehugger extends EntitySpeciesAlien implements IMob
 		this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(14.0D);
 		this.getEntityAttribute(SharedMonsterAttributes.movementSpeed).setBaseValue(0.5999999761581421D);
 		this.getEntityAttribute(SharedMonsterAttributes.attackDamage).setBaseValue(0.50D);
-		this.getEntityAttribute(SharedMonsterAttributes.followRange).setBaseValue(48.0D);
+		this.getEntityAttribute(SharedMonsterAttributes.followRange).setBaseValue(32.0D);
 	}
 
 	@Override
 	public void onUpdate()
 	{
 		super.onUpdate();
+		
+		this.fallDistance = 0F;
 		
 		if (this.isCollidedHorizontally)
 		{

--- a/src/main/java/com/arisux/avp/entities/mob/EntityHammerpede.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityHammerpede.java
@@ -81,6 +81,8 @@ public class EntityHammerpede extends EntitySpeciesAlien implements IMob
 	{
 		super.onUpdate();
 		
+		this.fallDistance = 0F;
+		
 		this.lurkInBlackGoo();
 		
 		if (this.getAttackTarget() == null && this.worldObj.getWorldTime() % 60 == 0 && this.rand.nextInt(3) == 0)

--- a/src/main/java/com/arisux/avp/entities/mob/EntityProtomorph.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityProtomorph.java
@@ -11,12 +11,6 @@ import net.minecraft.entity.ai.EntityAIWander;
 import net.minecraft.entity.ai.EntityAIHurtByTarget;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.monster.EntityWitch;
-import net.minecraft.entity.monster.EntitySpider;
-import net.minecraft.entity.monster.EntityCreeper;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.passive.EntityAnimal;
-import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
@@ -39,15 +33,7 @@ public class EntityProtomorph extends EntityXenomorph
 		this.tasks.addTask(1, new EntityAIAttackOnCollide(this, 0.800000011920929D, true));
 		this.tasks.addTask(1, new EntityAIWander(this, 0.800000011920929D));
 		this.targetTasks.addTask(1, new EntityAILeapAtTarget(this, 0.4F));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesYautja.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesEngineer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityMarine.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityPlayer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityVillager.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityAnimal.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityWitch.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpider.class, 0, true));
-		this.targetTasks.addTask(3, new EntityAIHurtByTarget(this, true));
+		this.targetTasks.addTask(2, new EntityAIHurtByTarget(this, true));
 	}
 
 	@Override

--- a/src/main/java/com/arisux/avp/entities/mob/EntityTrilobite.java
+++ b/src/main/java/com/arisux/avp/entities/mob/EntityTrilobite.java
@@ -1,6 +1,7 @@
 package com.arisux.avp.entities.mob;
 
 import com.arisux.avp.AliensVsPredator;
+import com.arisux.avp.entities.ai.alien.EntitySelectorXenomorph;
 
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.EntityAIAttackOnCollide;
@@ -10,13 +11,8 @@ import net.minecraft.entity.ai.EntityAISwimming;
 import net.minecraft.entity.ai.EntityAIWander;
 import net.minecraft.entity.ai.EntityAIHurtByTarget;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.monster.EntityWitch;
-import net.minecraft.entity.monster.EntitySpider;
-import net.minecraft.entity.monster.EntityCreeper;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.passive.EntityAnimal;
-import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
@@ -36,16 +32,8 @@ public class EntityTrilobite extends EntitySpeciesAlien implements IMob
 		this.tasks.addTask(1, new EntityAIAttackOnCollide(this, 0.800000011920929D, true));
 		this.tasks.addTask(1, new EntityAIWander(this, 0.800000011920929D));
 		this.targetTasks.addTask(1, new EntityAILeapAtTarget(this, 0.8F));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesYautja.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpeciesEngineer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityMarine.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityPlayer.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityVillager.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityAnimal.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityCreeper.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityWitch.class, 0, true));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntitySpider.class, 0, true));
-		this.targetTasks.addTask(3, new EntityAIHurtByTarget(this, true));
+		this.targetTasks.addTask(1, new EntityAINearestAttackableTarget(this, Entity.class, /** targetChance **/0, /** shouldCheckSight **/false, /** nearbyOnly **/false, EntitySelectorXenomorph.instance));
+		this.targetTasks.addTask(2, new EntityAIHurtByTarget(this, true));
 	}
 
 	@Override
@@ -75,6 +63,8 @@ public class EntityTrilobite extends EntitySpeciesAlien implements IMob
 	public void onUpdate()
 	{
 		super.onUpdate();
+		
+		this.fallDistance = 0F;
 	}
 
 	/* protected Entity findPlayerToAttack(EntityPlayer entityplayer)


### PR DESCRIPTION
resolved 223.  Took your advice and re-worked the targeting so that the Aliens use EntitySelectorXenomorph, which I modified to fix the behavior where Aliens would target AcidPool.  Temporarily fixed Xeno all climbing with an update call to isCollidedHorizontally until I can figure out why EntityAIClimb isn't behaving properly.  Minor tweak to BlockHandler as well.