### PR TITLE
General hive resin TE fixes.

### DIFF
--- a/src/main/java/org/avp/block/BlockHiveResin.java
+++ b/src/main/java/org/avp/block/BlockHiveResin.java
@@ -1,6 +1,9 @@
 package org.avp.block;
 
+import java.util.Random;
+
 import org.avp.tile.TileEntityHiveResin;
+import org.avp.tile.TileEntityHiveResin.ResinVariant;
 import org.avp.world.hives.HiveHandler;
 
 import com.asx.mdx.lib.world.Pos;
@@ -31,7 +34,7 @@ public class BlockHiveResin extends Block
     {
         return false;
     }
-    
+
     @Override
     public EnumBlockRenderType getRenderType(IBlockState state)
     {
@@ -90,5 +93,46 @@ public class BlockHiveResin extends Block
         }
 
         super.onBlockClicked(world, pos, playerIn);
+    }
+
+    @Override
+    public void onNeighborChange(IBlockAccess world, BlockPos pos, BlockPos neighbor)
+    {
+        evaluateNeighbors(world, pos);
+        super.onNeighborChange(world, pos, neighbor);
+    }
+
+    public void evaluateNeighbors(IBlockAccess world, BlockPos pos)
+    {
+        TileEntityHiveResin te = (TileEntityHiveResin) world.getTileEntity(pos);
+
+        if (te != null)
+        {
+            if (te.variant == null)
+            {
+                te.variant = ResinVariant.fromId(1 + new Random().nextInt(ResinVariant.values().length));
+            }
+
+            ResinVariant variant = te.variant;
+
+            te.bottomBlock = world.getBlockState(pos.add(0, -1, 0)).getBlock();
+            te.topBlock = world.getBlockState(pos.add(0, 1, 0)).getBlock();
+
+            te.northBlock = world.getBlockState(pos.add(variant.nX, 0, variant.nZ)).getBlock();
+            te.northTopBlock = world.getBlockState(pos.add(variant.nX, 1, variant.nZ)).getBlock();
+            te.northBottomBlock = world.getBlockState(pos.add(variant.nX, -1, variant.nZ)).getBlock();
+
+            te.southBlock = world.getBlockState(pos.add(variant.sX, 0, variant.sZ)).getBlock();
+            te.southTopBlock = world.getBlockState(pos.add(variant.sX, 1, variant.sZ)).getBlock();
+            te.southBottomBlock = world.getBlockState(pos.add(variant.sX, -1, variant.sZ)).getBlock();
+
+            te.eastBlock = world.getBlockState(pos.add(variant.eX, 0, variant.eZ)).getBlock();
+            te.eastTopBlock = world.getBlockState(pos.add(variant.eX, 1, variant.eZ)).getBlock();
+            te.eastBottomBlock = world.getBlockState(pos.add(variant.eX, -1, variant.eZ)).getBlock();
+
+            te.westBlock = world.getBlockState(pos.add(variant.wX, 0, variant.wZ)).getBlock();
+            te.westTopBlock = world.getBlockState(pos.add(variant.wX, 1, variant.wZ)).getBlock();
+            te.westBottomBlock = world.getBlockState(pos.add(variant.wX, -1, variant.wZ)).getBlock();
+        }
     }
 }

--- a/src/main/java/org/avp/client/render/tile/RenderHiveResin.java
+++ b/src/main/java/org/avp/client/render/tile/RenderHiveResin.java
@@ -21,7 +21,7 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
 
         if (hiveTessellation == GraphicsSetting.MEDIUM || hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
         {
-            TileEntityHiveResin resin = (TileEntityHiveResin) tile;
+            TileEntityHiveResin resin = tile;
 
             OpenGL.pushMatrix();
             {
@@ -30,10 +30,11 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
                 AliensVsPredator.resources().models().HIVE_RESIN.bindTexture();
                 ModelHiveResin model = AliensVsPredator.resources().models().HIVE_RESIN.getModel();
                 OpenGL.enableCullFace();
+                OpenGL.disableLight();
 
                 if (resin.topBlock == Blocks.AIR)
                 {
-                    if (hiveTessellation == GraphicsSetting.MEDIUM ||hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
+                    if (hiveTessellation == GraphicsSetting.MEDIUM || hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
                     {
                         model.blockFaceTop.offsetY = 2.002F;
                         model.blockFaceTop.rotateAngleX = (float) Math.toRadians(180);
@@ -53,7 +54,8 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
 
                 OpenGL.rotate(resin.getVariant() == null ? 0 : (resin.getVariant().id - 1) * 90F, 0F, 1F, 0F);
 
-                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
+                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation ==
+                // GraphicsSetting.ULTRA)
                 {
                     model.nBottomRoot01.isHidden = resin.northTopBlock == Blocks.AIR;
                     model.nTopRoot01.isHidden = resin.northBottomBlock == Blocks.AIR;
@@ -76,7 +78,8 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
                     }
                 }
 
-                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
+                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation ==
+                // GraphicsSetting.ULTRA)
                 {
                     model.wBottomRoot01.isHidden = resin.westTopBlock == Blocks.AIR;
                     model.wTopRoot01.isHidden = resin.westBottomBlock == Blocks.AIR;
@@ -97,7 +100,8 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
                     }
                 }
 
-                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
+                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation ==
+                // GraphicsSetting.ULTRA)
                 {
                     model.sBottomRoot01.isHidden = resin.southTopBlock == Blocks.AIR;
                     model.sTopRoot01.isHidden = resin.southBottomBlock == Blocks.AIR;
@@ -119,7 +123,8 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
                     }
                 }
 
-//                if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation == GraphicsSetting.ULTRA)
+                // if (hiveTessellation == GraphicsSetting.HIGH || hiveTessellation ==
+                // GraphicsSetting.ULTRA)
                 {
                     model.eBottomRoot01.isHidden = resin.eastTopBlock == Blocks.AIR;
                     model.eTopRoot01.isHidden = resin.eastBottomBlock == Blocks.AIR;
@@ -140,6 +145,7 @@ public class RenderHiveResin extends TileEntitySpecialRenderer<TileEntityHiveRes
                     }
                 }
             }
+            OpenGL.enableLight();
             OpenGL.popMatrix();
         }
     }

--- a/src/main/java/org/avp/tile/TileEntityHiveResin.java
+++ b/src/main/java/org/avp/tile/TileEntityHiveResin.java
@@ -3,6 +3,7 @@ package org.avp.tile;
 import java.util.Random;
 import java.util.UUID;
 
+import org.avp.block.BlockHiveResin;
 import org.avp.world.hives.HiveHandler;
 import org.avp.world.hives.XenomorphHive;
 
@@ -14,30 +15,29 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ITickable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 //TODO: Redo this
-public class TileEntityHiveResin extends TileEntity implements ITickable
+public class TileEntityHiveResin extends TileEntity
 {
-    private ResinVariant variant;
-    private UUID         signature;
-    private IBlockState  blockCovering;
-    public Block         northBlock;
-    public Block         northTopBlock;
-    public Block         northBottomBlock;
-    public Block         southBlock;
-    public Block         southTopBlock;
-    public Block         southBottomBlock;
-    public Block         eastBlock;
-    public Block         eastTopBlock;
-    public Block         eastBottomBlock;
-    public Block         westBlock;
-    public Block         westTopBlock;
-    public Block         westBottomBlock;
-    public Block         bottomBlock;
-    public Block         topBlock;
+    public ResinVariant variant;
+    private UUID        signature;
+    private IBlockState blockCovering;
+    public Block        northBlock;
+    public Block        northTopBlock;
+    public Block        northBottomBlock;
+    public Block        southBlock;
+    public Block        southTopBlock;
+    public Block        southBottomBlock;
+    public Block        eastBlock;
+    public Block        eastTopBlock;
+    public Block        eastBottomBlock;
+    public Block        westBlock;
+    public Block        westTopBlock;
+    public Block        westBottomBlock;
+    public Block        bottomBlock;
+    public Block        topBlock;
 
     public enum ResinVariant
     {
@@ -84,36 +84,10 @@ public class TileEntityHiveResin extends TileEntity implements ITickable
     }
 
     @Override
-    public void update()
+    public void onLoad()
     {
-        if (this.world.getWorldTime() % 20 == 0)
-        {
-            if (variant != null)
-            {
-                bottomBlock = this.world.getBlockState(this.getPos().add(0, -1, 0)).getBlock();
-                topBlock = this.world.getBlockState(this.getPos().add(0, 1, 0)).getBlock();
-
-                northBlock = this.world.getBlockState(this.getPos().add(variant.nX, 0, variant.nZ)).getBlock();
-                northTopBlock = this.world.getBlockState(this.getPos().add(variant.nX, 1, variant.nZ)).getBlock();
-                northBottomBlock = this.world.getBlockState(this.getPos().add(variant.nX, -1, variant.nZ)).getBlock();
-
-                southBlock = this.world.getBlockState(this.getPos().add(variant.sX, 0, variant.sZ)).getBlock();
-                southTopBlock = this.world.getBlockState(this.getPos().add(variant.sX, 1, variant.sZ)).getBlock();
-                southBottomBlock = this.world.getBlockState(this.getPos().add(variant.sX, -1, variant.sZ)).getBlock();
-
-                eastBlock = this.world.getBlockState(this.getPos().add(variant.eX, 0, variant.eZ)).getBlock();
-                eastTopBlock = this.world.getBlockState(this.getPos().add(variant.eX, 1, variant.eZ)).getBlock();
-                eastBottomBlock = this.world.getBlockState(this.getPos().add(variant.eX, -1, variant.eZ)).getBlock();
-
-                westBlock = this.world.getBlockState(this.getPos().add(variant.wX, 0, variant.wZ)).getBlock();
-                westTopBlock = this.world.getBlockState(this.getPos().add(variant.wX, 1, variant.wZ)).getBlock();
-                westBottomBlock = this.world.getBlockState(this.getPos().add(variant.wX, -1, variant.wZ)).getBlock();
-            }
-            else
-            {
-                this.variant = ResinVariant.fromId(1 + new Random().nextInt(ResinVariant.values().length));
-            }
-        }
+        super.onLoad();
+        ((BlockHiveResin) world.getBlockState(pos).getBlock()).evaluateNeighbors(world, pos);
     }
 
     public XenomorphHive getHive()


### PR DESCRIPTION
This PR adds the following fixes for hive resin tile entities:
- Their tile entities no longer tick. This should improve performance with large hives.
- They now render properly (previously their sides were rendering too dark, but now they've been corrected to match the block texture).