### PR TITLE
Premature xenomorph fixes and overall mod optimizations.

### DIFF
--- a/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
+++ b/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
@@ -236,15 +236,18 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
     @Override
     protected void collideWithNearbyEntities()
     {
-        List<Entity> list = this.world.getEntitiesWithinAABBExcludingEntity(this, this.getEntityBoundingBox());
-
-        if (list != null && !list.isEmpty())
+        if(this.isFertile()) 
         {
-            for (int i = 0; i < list.size(); ++i)
+            List<Entity> list = this.world.getEntitiesWithinAABBExcludingEntity(this, this.getEntityBoundingBox());
+    
+            if (list != null && !list.isEmpty())
             {
-                Entity entity = list.get(i);
-
-                this.collideWithEntity(entity);
+                for (int i = 0; i < list.size(); ++i)
+                {
+                    Entity entity = list.get(i);
+    
+                    this.collideWithEntity(entity);
+                }
             }
         }
     }

--- a/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
+++ b/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
@@ -140,12 +140,9 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
         {
             this.setNoAI(true);
 
-            this.motionY -= 0.25F;
-
-            this.motionX *= 0.98F;
+            this.motionY -= 0.05F;
             this.motionY *= 0.98F;
-            this.motionZ *= 0.98F;
-            this.move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
+            this.move(MoverType.SELF, 0, this.motionY, 0);
         }
 
         if (this.world.getWorldTime() % 20 == 0)
@@ -246,7 +243,7 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
         {
             for (int i = 0; i < list.size(); ++i)
             {
-                Entity entity = (Entity) list.get(i);
+                Entity entity = list.get(i);
 
                 this.collideWithEntity(entity);
             }
@@ -333,6 +330,7 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
         return false;
     }
 
+    @Override
     public boolean isPotionApplicable(PotionEffect effect)
     {
         return effect.getPotion() == MobEffects.POISON ? false : super.isPotionApplicable(effect);

--- a/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
+++ b/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
@@ -177,11 +177,10 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
                 EntityLiving living = (EntityLiving) this.getRidingEntity();
 
                 living.setNoAI(true);
-                living.motionY -= 0.25F;
-                living.motionX *= 0.98F;
+                
+                living.motionY -= 0.05F;
                 living.motionY *= 0.98F;
-                living.motionZ *= 0.98F;
-                living.move(MoverType.SELF, living.motionX, living.motionY, living.motionZ);
+                living.move(MoverType.SELF, 0, living.motionY, 0);
 
                 this.rotationYawHead = living.rotationYawHead;
                 this.rotationYaw = living.rotationYaw;

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityOvamorph.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityOvamorph.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.monster.IMob;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
@@ -155,6 +156,10 @@ public class EntityOvamorph extends SpeciesAlien implements IMob
     protected void collideWithEntity(Entity entity)
     {
         super.collideWithEntity(entity);
+        if((entity instanceof EntityPlayer) && !((EntityPlayer)entity).capabilities.isCreativeMode || !(entity instanceof SpeciesAlien) && !(entity instanceof EntityPlayer))
+        {
+            this.hatchingTime = 0;
+        }
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/parasites/EntityFacehugger.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/parasites/EntityFacehugger.java
@@ -97,6 +97,6 @@ public class EntityFacehugger extends EntityParasitoid implements IMob, IParasit
     @Override
     protected SoundEvent getDeathSound()
     {
-        return Sounds.FACEHUGGER_DEATH.event();
+        return this.isFertile() ? Sounds.FACEHUGGER_DEATH.event() : super.getDeathSound();
     }
 }


### PR DESCRIPTION
This PR includes the following adjustments and fixes:
- Infertile parasites won't slide when they're attacked. They'll just remain stationary. Same for their hosts they're attached to.
- Facehuggers no longer make sounds even though they're dead. That's just weird.
- Ovamorphs can now hatch immediately if a non-alien entity such as a player or villager bumps into them.
- Dead facehuggers can no longer be collided with. You can just walk right over them.
- Optimized entity tick events. Previously the mod was looping 3x through all loaded entities on the client's end. This pull request fixes that, so now it's only one on each networking side.
- Optimized how xenomorph hives work. This optimization reduces the garbage collector cleanup time by avoiding clone() references. It also makes use of hashing aliens and hives to maps, so now hives and aliens can be increased without a hit to performance.