### PR TITLE
Further optimizations and fixes with entities and logical checks.

### DIFF
--- a/src/main/java/org/avp/EntityHandler.java
+++ b/src/main/java/org/avp/EntityHandler.java
@@ -3,6 +3,7 @@ package org.avp;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 
 import org.avp.entities.EntityAPC;
 import org.avp.entities.EntityAcidPool;
@@ -33,7 +34,6 @@ import org.avp.entities.living.species.engineer.EntitySpaceJockey;
 import org.avp.entities.living.species.species223ode.EntityDeacon;
 import org.avp.entities.living.species.species223ode.EntityDeaconAdult;
 import org.avp.entities.living.species.species223ode.EntityTrilobite;
-import org.avp.entities.living.species.xenomorphs.EntityNauticomorph;
 import org.avp.entities.living.species.xenomorphs.EntityBatXeno;
 import org.avp.entities.living.species.xenomorphs.EntityBoiler;
 import org.avp.entities.living.species.xenomorphs.EntityChestburster;
@@ -43,6 +43,7 @@ import org.avp.entities.living.species.xenomorphs.EntityDracomorph;
 import org.avp.entities.living.species.xenomorphs.EntityDrone;
 import org.avp.entities.living.species.xenomorphs.EntityMatriarch;
 import org.avp.entities.living.species.xenomorphs.EntityMyceliomorph;
+import org.avp.entities.living.species.xenomorphs.EntityNauticomorph;
 import org.avp.entities.living.species.xenomorphs.EntityOvamorph;
 import org.avp.entities.living.species.xenomorphs.EntityPantheramorph;
 import org.avp.entities.living.species.xenomorphs.EntityPraetorian;
@@ -374,18 +375,16 @@ public class EntityHandler implements IInitEvent
 
     public ArrayList<Biome> filterOverworldBiomes(ArrayList<Biome> biomes)
     {
-        @SuppressWarnings("unchecked")
-        ArrayList<Biome> newList = (ArrayList<Biome>) biomes.clone();
+        Iterator<Biome> iter = biomes.iterator();
 
-        for (Biome b : getOverworldBiomeList())
+        while (iter.hasNext())
         {
-            if (newList.contains(b))
-            {
-                newList.remove(b);
-            }
+            Biome biome = iter.next();
+            if (biomes.contains(biome))
+                iter.remove();
         }
 
-        return newList;
+        return biomes;
     }
 
     public static ArrayList<Biome> getOverworldBiomeList()

--- a/src/main/java/org/avp/client/gui/GuiBlastdoor.java
+++ b/src/main/java/org/avp/client/gui/GuiBlastdoor.java
@@ -117,7 +117,7 @@ public class GuiBlastdoor extends GuiCustomScreen
                 GlStateManager.enableBlend();
                 Draw.drawRect(screenX, screenY + headerHeight, guiWidth, 13, 0xEE000000);
 
-                if (Game.minecraft().world.getWorldTime() % 20 <= 10)
+                if (Game.minecraft().world.getTotalWorldTime() % 20 <= 10)
                 {
                     Draw.drawString(status, screenX + padding, screenY + headerHeight + padding, 0xFFFF0000, false);
                 }

--- a/src/main/java/org/avp/client/model/entities/living/ModelNauticomorph.java
+++ b/src/main/java/org/avp/client/model/entities/living/ModelNauticomorph.java
@@ -310,7 +310,7 @@ public class ModelNauticomorph extends Model<EntityNauticomorph>
     {
         float swingProgress = swingProgress(e);
         float swingProgressPrev = swingProgressPrev(e);
-        float tailAngle = MathHelper.cos((Minecraft.getMinecraft().world.getWorldTime() % 360 + Game.partialTicks()) * (e != null && e.motionX + e.motionZ != 0 ? 0.67F : 0.07F));
+        float tailAngle = MathHelper.cos((Minecraft.getMinecraft().world.getTotalWorldTime() % 360 + Game.partialTicks()) * (e != null && e.motionX + e.motionZ != 0 ? 0.67F : 0.07F));
 
         if (e != null)
         {

--- a/src/main/java/org/avp/client/model/entities/living/ModelUltramorph.java
+++ b/src/main/java/org/avp/client/model/entities/living/ModelUltramorph.java
@@ -316,7 +316,7 @@ public class ModelUltramorph extends Model
 
         float swingProgress = swingProgress(obj);
         float swingProgressPrev = swingProgressPrev(obj);
-        float tailAngle = MathHelper.cos((Minecraft.getMinecraft().world.getWorldTime() % 360 + Game.partialTicks()) * (base != null && base.motionX + base.motionZ != 0 ? 0.67F : 0.07F));
+        float tailAngle = MathHelper.cos((Minecraft.getMinecraft().world.getTotalWorldTime() % 360 + Game.partialTicks()) * (base != null && base.motionX + base.motionZ != 0 ? 0.67F : 0.07F));
 
         if (xenomorph != null)
         {

--- a/src/main/java/org/avp/client/model/tile/ModelRepulsionGenerator.java
+++ b/src/main/java/org/avp/client/model/tile/ModelRepulsionGenerator.java
@@ -140,7 +140,7 @@ public class ModelRepulsionGenerator extends Model
         if (obj instanceof TileEntityRepulsionGenerator)
         {
             TileEntityRepulsionGenerator generator = (TileEntityRepulsionGenerator) obj;
-            this.rotor.rotateAngleY = ((Minecraft.getMinecraft().player.world.getWorldTime() % 360) + Game.partialTicks()) * (generator.getRotationSpeed());
+            this.rotor.rotateAngleY = ((Minecraft.getMinecraft().player.world.getTotalWorldTime() % 360) + Game.partialTicks()) * (generator.getRotationSpeed());
         }
 
         this.wireframe2.render(DEFAULT_SCALE);

--- a/src/main/java/org/avp/client/render/BossBarEvent.java
+++ b/src/main/java/org/avp/client/render/BossBarEvent.java
@@ -41,7 +41,7 @@ public class BossBarEvent
     {
         if (Game.minecraft().player != null)
         {
-            if (Game.minecraft().player.world.getWorldTime() % 40 == 0)
+            if (Game.minecraft().player.world.getTotalWorldTime() % 40 == 0)
             {
                 for (Object o : Game.minecraft().world.loadedEntityList)
                 {

--- a/src/main/java/org/avp/client/render/PressureHUDRenderEvent.java
+++ b/src/main/java/org/avp/client/render/PressureHUDRenderEvent.java
@@ -391,7 +391,7 @@ public class PressureHUDRenderEvent
             EntityPlayer player = (EntityPlayer) living;
             Organism organism = (Organism) living.getCapability(Provider.CAPABILITY, null);
 
-            if (organism.hasEmbryo() && living.world.getWorldTime() % 20 <= 10)
+            if (organism.hasEmbryo() && living.world.getTotalWorldTime() % 20 <= 10)
             {
                 ScaledResolution res = Screen.scaledDisplayResolution();
                 int lifeTimeTicks = organism.getEmbryo().getGestationPeriod() - organism.getEmbryo().getAge();

--- a/src/main/java/org/avp/client/render/RenderPlayerPlasmaCannon.java
+++ b/src/main/java/org/avp/client/render/RenderPlayerPlasmaCannon.java
@@ -209,7 +209,7 @@ public class RenderPlayerPlasmaCannon implements IEventRenderer, IFirstPersonRen
                         // OpenGL.enableLight();
                         MODEL_FIRST_PERSON.draw();
 
-                        float rotation = (entity.world.getWorldTime() + partialTicks) % 360;
+                        float rotation = (entity.world.getTotalWorldTime() + partialTicks) % 360;
                         double wave = Math.sin(rotation);
 
                         OpenGL.pushMatrix();

--- a/src/main/java/org/avp/client/render/TacticalHUDRenderEvent.java
+++ b/src/main/java/org/avp/client/render/TacticalHUDRenderEvent.java
@@ -73,7 +73,7 @@ public class TacticalHUDRenderEvent
         {
             if (Inventories.getHelmSlotItemStack(Game.minecraft().player) != null && Inventories.getHelmSlotItemStack(Game.minecraft().player).getItem() == AliensVsPredator.items().helmMarine)
             {
-                if (Game.minecraft().world != null && Game.minecraft().world.getWorldTime() % (20 * 3) == 0)
+                if (Game.minecraft().world != null && Game.minecraft().world.getTotalWorldTime() % (20 * 3) == 0)
                 {
                     if (trackedEntities != null)
                     {

--- a/src/main/java/org/avp/client/render/entities/RenderAPC.java
+++ b/src/main/java/org/avp/client/render/entities/RenderAPC.java
@@ -194,7 +194,7 @@ public class RenderAPC extends Render<EntityAPC>
                     || model.getPart("Mesh221_APCHndPt1_Model") == p)
             {
                 OpenGL.pushMatrix();
-                float doorProgress = (float) (-1.25 * Game.minecraft().world.getWorldTime() % 315 / 100);
+                float doorProgress = (float) (-1.25 * Game.minecraft().world.getTotalWorldTime() % 315 / 100);
                 OpenGL.translate(Math.sin(doorProgress), 0, 0);
                 p.draw();
                 OpenGL.popMatrix();

--- a/src/main/java/org/avp/client/render/entities/RenderShuriken.java
+++ b/src/main/java/org/avp/client/render/entities/RenderShuriken.java
@@ -32,7 +32,7 @@ public class RenderShuriken extends Render<EntityShuriken>
             
             if (!entity.isInGround())
             {
-                OpenGL.rotate(360 - (entity.world.getWorldTime() % 360 + Game.partialTicks()) * 60, 0, 1, 0);
+                OpenGL.rotate(360 - (entity.world.getTotalWorldTime() % 360 + Game.partialTicks()) * 60, 0, 1, 0);
             }
             
             OpenGL.translate(-0.5F, 0.0F, -0.5F);

--- a/src/main/java/org/avp/client/render/items/ItemRendererGroup.java
+++ b/src/main/java/org/avp/client/render/items/ItemRendererGroup.java
@@ -86,7 +86,7 @@ public class ItemRendererGroup<MODEL extends Model> extends ItemRenderer<MODEL>
     @Override
     public void renderInWorld(ItemStack itemstack, EntityLivingBase entity, TransformType cameraTransformType)
     {
-        OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+        OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
         this.renderPart();
     }
 }

--- a/src/main/java/org/avp/client/render/items/RenderItemAPC.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemAPC.java
@@ -85,7 +85,7 @@ public class RenderItemAPC extends ItemRenderer<Model>
         {
             OpenGL.scale(0.2F, 0.2F, 0.2F);
             OpenGL.translate(0, -1F, 0);
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
 
             for (Part p : AliensVsPredator.resources().models().M577_APC.parts.values())
             {

--- a/src/main/java/org/avp/client/render/items/RenderItemGunLocker.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemGunLocker.java
@@ -57,7 +57,7 @@ public class RenderItemGunLocker extends ItemRenderer<ModelLocker>
     {
         OpenGL.scale(1F, -1F, 1F);
         OpenGL.translate(0F, -1.5F, 0F);
-        OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+        OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
         GlStateManager.disableCull();
         this.getModel().draw();
     }

--- a/src/main/java/org/avp/client/render/items/RenderItemSatelliteDish.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemSatelliteDish.java
@@ -53,7 +53,7 @@ public class RenderItemSatelliteDish extends ItemRenderer<ModelSatelliteDish>
         OpenGL.translate(0.3F, 0F, 0F);
         OpenGL.rotate(230F, 1F, 0F, 0F);
         OpenGL.rotate(45F, 0F, 0F, 1F);
-        OpenGL.rotate(90F + Game.minecraft().world.getWorldTime() % 360 + Game.partialTicks(), 0.0F, 1.0F, 0.0F);
+        OpenGL.rotate(90F + Game.minecraft().world.getTotalWorldTime() % 360 + Game.partialTicks(), 0.0F, 1.0F, 0.0F);
         this.getModel().draw();
     }
 

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItem88Mod4Action.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItem88Mod4Action.java
@@ -40,7 +40,7 @@ public class RenderItem88Mod4Action extends ItemRendererGroup<Model88MOD4>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItem88Mod4Barrel.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItem88Mod4Barrel.java
@@ -40,7 +40,7 @@ public class RenderItem88Mod4Barrel extends ItemRendererGroup<Model88MOD4>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItem88Mod4Stock.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItem88Mod4Stock.java
@@ -40,7 +40,7 @@ public class RenderItem88Mod4Stock extends ItemRendererGroup<Model88MOD4>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemAK47Action.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemAK47Action.java
@@ -40,7 +40,7 @@ public class RenderItemAK47Action extends ItemRendererGroup<ModelAK47>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemAK47Barrel.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemAK47Barrel.java
@@ -40,7 +40,7 @@ public class RenderItemAK47Barrel extends ItemRendererGroup<ModelAK47>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemAK47Stock.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemAK47Stock.java
@@ -40,7 +40,7 @@ public class RenderItemAK47Stock extends ItemRendererGroup<ModelAK47>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41AAction.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41AAction.java
@@ -40,7 +40,7 @@ public class RenderItemM41AAction extends ItemRendererGroup<ModelM41A>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41ABarrel.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41ABarrel.java
@@ -40,7 +40,7 @@ public class RenderItemM41ABarrel extends ItemRendererGroup<ModelM41A>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41APeripherals.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41APeripherals.java
@@ -40,7 +40,7 @@ public class RenderItemM41APeripherals extends ItemRendererGroup<ModelM41A>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41AStock.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM41AStock.java
@@ -40,7 +40,7 @@ public class RenderItemM41AStock extends ItemRendererGroup<ModelM41A>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM4Action.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM4Action.java
@@ -40,7 +40,7 @@ public class RenderItemM4Action extends ItemRendererGroup<ModelM4>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM4Barrel.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM4Barrel.java
@@ -40,7 +40,7 @@ public class RenderItemM4Barrel extends ItemRendererGroup<ModelM4>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM4Stock.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM4Stock.java
@@ -40,7 +40,7 @@ public class RenderItemM4Stock extends ItemRendererGroup<ModelM4>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGAction.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGAction.java
@@ -40,7 +40,7 @@ public class RenderItemM56SGAction extends ItemRendererGroup<ModelM56SG>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGAimingModule.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGAimingModule.java
@@ -40,7 +40,7 @@ public class RenderItemM56SGAimingModule extends ItemRendererGroup<ModelM56SG>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGBarrel.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGBarrel.java
@@ -40,7 +40,7 @@ public class RenderItemM56SGBarrel extends ItemRendererGroup<ModelM56SG>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGStock.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGStock.java
@@ -40,7 +40,7 @@ public class RenderItemM56SGStock extends ItemRendererGroup<ModelM56SG>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGSupportFrame.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemM56SGSupportFrame.java
@@ -40,7 +40,7 @@ public class RenderItemM56SGSupportFrame extends ItemRendererGroup<ModelM56SG>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperAction.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperAction.java
@@ -40,7 +40,7 @@ public class RenderItemSniperAction extends ItemRendererGroup<ModelSniper>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperBarrel.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperBarrel.java
@@ -41,7 +41,7 @@ public class RenderItemSniperBarrel extends ItemRendererGroup<ModelSniper>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperPeripherals.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperPeripherals.java
@@ -40,7 +40,7 @@ public class RenderItemSniperPeripherals extends ItemRendererGroup<ModelSniper>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperScope.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperScope.java
@@ -41,7 +41,7 @@ public class RenderItemSniperScope extends ItemRendererGroup<ModelSniper>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperStock.java
+++ b/src/main/java/org/avp/client/render/items/firearms/parts/RenderItemSniperStock.java
@@ -40,7 +40,7 @@ public class RenderItemSniperStock extends ItemRendererGroup<ModelSniper>
     {
         OpenGL.pushMatrix();
         {
-            OpenGL.rotate((Game.minecraft().world.getWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
+            OpenGL.rotate((Game.minecraft().world.getTotalWorldTime() + Game.partialTicks() % 360) * 10, 0.0F, 1.0F, 0.0F);
             GlStateManager.disableCull();
             this.renderPart();
         }

--- a/src/main/java/org/avp/client/render/tile/RenderAssembler.java
+++ b/src/main/java/org/avp/client/render/tile/RenderAssembler.java
@@ -25,7 +25,7 @@ public class RenderAssembler extends TileEntitySpecialRenderer<TileEntityAssembl
             OpenGL.enable(GL_BLEND);
             OpenGL.blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             OpenGL.translate(posX + 0.5F, posY + 0.95F, posZ + 0.5F);
-            OpenGL.rotate(tile.getWorld().getWorldTime() % 360 * 12, 0, 1, 0);
+            OpenGL.rotate(tile.getWorld().getTotalWorldTime() % 360 * 12, 0, 1, 0);
 
             OpenGL.pushMatrix();
             {

--- a/src/main/java/org/avp/client/render/tile/RenderWorkstation.java
+++ b/src/main/java/org/avp/client/render/tile/RenderWorkstation.java
@@ -65,7 +65,7 @@ public class RenderWorkstation extends TileEntitySpecialRenderer<TileEntityWorks
             OpenGL.rotate(6.5F, 1F, 0F, 0F);
             OpenGL.scale(-textscale, textscale, textscale);
 
-            if (tile.getWorld().getWorldTime() % 40 == 0)
+            if (tile.getWorld().getTotalWorldTime() % 40 == 0)
             {
                 try
                 {

--- a/src/main/java/org/avp/client/render/wavegraph/Wavegraph.java
+++ b/src/main/java/org/avp/client/render/wavegraph/Wavegraph.java
@@ -54,7 +54,7 @@ public class Wavegraph
     {
         this.newdata = false;
 
-        if (world.getWorldTime() % Math.floor((60D / this.rate) * 20) == 0 && !Game.minecraft().isGamePaused())
+        if (world.getTotalWorldTime() % Math.floor((60D / this.rate) * 20) == 0 && !Game.minecraft().isGamePaused())
         {
             this.newdata = true;
             long start = System.currentTimeMillis();

--- a/src/main/java/org/avp/client/render/wavegraph/ekg/Electrocardiogram.java
+++ b/src/main/java/org/avp/client/render/wavegraph/ekg/Electrocardiogram.java
@@ -41,7 +41,7 @@ public class Electrocardiogram extends Wavegraph
     {
         this.newdata = false;
 
-        if (world.getWorldTime() % Math.floor((60D / this.rate) * 20) == 0 && !Game.minecraft().isGamePaused())
+        if (world.getTotalWorldTime() % Math.floor((60D / this.rate) * 20) == 0 && !Game.minecraft().isGamePaused())
         {
             this.newdata = true;
             long start = System.currentTimeMillis();

--- a/src/main/java/org/avp/entities/EntityAcidPool.java
+++ b/src/main/java/org/avp/entities/EntityAcidPool.java
@@ -116,7 +116,7 @@ public class EntityAcidPool extends EntityLiquidPool implements IMob
             }
         }
 
-        if (world.isRemote && world.getWorldTime() % 4 <= 0)
+        if (world.isRemote && world.getTotalWorldTime() % 4 <= 0)
         {
             this.world.spawnParticle(EnumParticleTypes.SMOKE_NORMAL, this.posX + this.rand.nextDouble(), this.posY + this.rand.nextDouble(), this.posZ + this.rand.nextDouble(), 0.0D, 0.0D, 0.0D);
         }

--- a/src/main/java/org/avp/entities/EntityLaserMine.java
+++ b/src/main/java/org/avp/entities/EntityLaserMine.java
@@ -86,7 +86,7 @@ public class EntityLaserMine extends Entity
     {
         super.onUpdate();
 
-        if (this.world.getWorldTime() % 10 == 0)
+        if (this.world.getTotalWorldTime() % 10 == 0)
         {
             this.laserHit = Entities.rayTraceAll(this, this.getLaserMaxDepth());
         }

--- a/src/main/java/org/avp/entities/EntityMechanism.java
+++ b/src/main/java/org/avp/entities/EntityMechanism.java
@@ -32,7 +32,7 @@ public class EntityMechanism extends Entity
     {
         super.onUpdate();
 
-        if (this.world.getWorldTime() % 20 == 0)
+        if (this.world.getTotalWorldTime() % 20 == 0)
         {
             Block block = this.world.getBlockState(new BlockPos((int) this.posX, (int) this.posY, (int) this.posZ - 1)).getBlock();
 

--- a/src/main/java/org/avp/entities/EntityWristbracer.java
+++ b/src/main/java/org/avp/entities/EntityWristbracer.java
@@ -78,7 +78,7 @@ public class EntityWristbracer extends EntityThrowable
             this.motionY *= -0.5D;
         }
 
-        if (this.world.getWorldTime() % 20 == 0)
+        if (this.world.getTotalWorldTime() % 20 == 0)
         {
             Sounds.fxWristbracerAlarm.playSound(this, 15F, 1F);
         }

--- a/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
+++ b/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
@@ -145,7 +145,7 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
             this.move(MoverType.SELF, 0, this.motionY, 0);
         }
 
-        if (this.world.getWorldTime() % 20 == 0)
+        if (this.world.getTotalWorldTime() % 20 == 0)
         {
             if (isFertile())
             {
@@ -198,7 +198,7 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
     @Override
     public boolean canProduceJelly()
     {
-        return this.world.getWorldTime() % this.getJellyProductionRate() == 0 && this.isFertile() && this.getJellyLevel() <= 256;
+        return this.world.getTotalWorldTime() % this.getJellyProductionRate() == 0 && this.isFertile() && this.getJellyLevel() <= 256;
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
@@ -131,10 +131,9 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
                 adjustedLevel = adjustedLevel < 64 ? adjustedLevel : 64;
             }
 
-            ItemDrop dynamicJelly = new ItemDrop(100, new ItemStack(AliensVsPredator.items().itemRoyalJelly, adjustedLevel));
             if (this.isDependant)
             {
-                dynamicJelly.tryDrop(this);
+                new ItemDrop(100, new ItemStack(AliensVsPredator.items().itemRoyalJelly, adjustedLevel)).tryDrop(this);
             }
         }
     }

--- a/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
@@ -267,7 +267,7 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
     @Override
     public boolean canProduceJelly()
     {
-        return this.world.getWorldTime() % this.getJellyProductionRate() == 0;
+        return this.world.getTotalWorldTime() % this.getJellyProductionRate() == 0;
     }
 
     @Override
@@ -281,7 +281,7 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 // this.setJellyLevel(this.getJellyLevel() + 20);
             }

--- a/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
@@ -8,7 +8,6 @@ import org.avp.DamageSources;
 import org.avp.api.parasitoidic.IMaturable;
 import org.avp.api.parasitoidic.IRoyalOrganism;
 import org.avp.entities.EntityAcidPool;
-import org.avp.entities.living.species.xenomorphs.EntityDrone;
 import org.avp.entities.living.species.xenomorphs.EntityMatriarch;
 import org.avp.entities.living.species.xenomorphs.EntityOvamorph;
 import org.avp.world.hives.HiveHandler;
@@ -73,7 +72,7 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
         super.writeEntityToNBT(nbt);
         this.writeAlienToNBT(nbt);
     }
-    
+
     public void writeAlienToNBT(NBTTagCompound nbt)
     {
         nbt.setString("HiveSignature", signature != null ? this.signature.toString() : "");
@@ -86,7 +85,7 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
         super.readEntityFromNBT(nbt);
         this.readAlienFromNBT(nbt);
     }
-    
+
     public void readAlienFromNBT(NBTTagCompound nbt)
     {
         this.signature = Worlds.uuidFromNBT(nbt, "HiveSignature");
@@ -143,7 +142,7 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
     public boolean isReadyToMature(IRoyalOrganism jellyProducer)
     {
         IMaturable maturable = (IMaturable) this;
-        IRoyalOrganism ro = (IRoyalOrganism) this;
+        IRoyalOrganism ro = this;
         return maturable.getMatureState() != null && maturable.getMaturityLevel() > 0 && ro.getJellyLevel() >= maturable.getMaturityLevel();
     }
 

--- a/src/main/java/org/avp/entities/living/species/SpeciesXenomorph.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesXenomorph.java
@@ -171,7 +171,7 @@ public abstract class SpeciesXenomorph extends SpeciesAlien implements IMob
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % ((20 * 4) + (20 * this.rand.nextInt(32))) == 0)
+            if (this.world.getTotalWorldTime() % ((20 * 4) + (20 * this.rand.nextInt(32))) == 0)
             {
                 this.bite();
             }

--- a/src/main/java/org/avp/entities/living/species/SpeciesYautja.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesYautja.java
@@ -92,7 +92,7 @@ public abstract class SpeciesYautja extends EntityMob implements IHost, Predicat
     {
         super.onUpdate();
         
-        if (this.world.getWorldTime() % 10 == 0)
+        if (this.world.getTotalWorldTime() % 10 == 0)
         {
             BlockPos aboveHead = this.getPosition().add(0, 3, 0);
             this.setDucking(this.world.getBlockState(aboveHead).getBlock() != Blocks.AIR);
@@ -123,7 +123,7 @@ public abstract class SpeciesYautja extends EntityMob implements IHost, Predicat
         {
             this.playSound(this.getFallSound(intensity), 1.0F, 1.0F);
             
-            if (this.world.getWorldTime() % 4 == 0)
+            if (this.world.getTotalWorldTime() % 4 == 0)
             this.playSound(this.getDeathSound(), 1.0F, 1.0F);
             
             int x = MathHelper.floor(this.posX);

--- a/src/main/java/org/avp/entities/living/species/species223ode/EntityDeacon.java
+++ b/src/main/java/org/avp/entities/living/species/species223ode/EntityDeacon.java
@@ -147,7 +147,7 @@ public class EntityDeacon extends Species223ODe implements INascentic
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 this.setJellyLevel(this.getJellyLevel() + 20);
             }

--- a/src/main/java/org/avp/entities/living/species/species223ode/EntityTrilobite.java
+++ b/src/main/java/org/avp/entities/living/species/species223ode/EntityTrilobite.java
@@ -188,7 +188,7 @@ public class EntityTrilobite extends Species223ODe implements IParasitoid, IAnim
 
     private void updateHitbox()
     {
-        if (this.world.getWorldTime() % 20 == 0)
+        if (this.world.getTotalWorldTime() % 20 == 0)
         {
             if (!this.isFertile() && this.getRidingEntity() == null)
             {
@@ -261,7 +261,7 @@ public class EntityTrilobite extends Species223ODe implements IParasitoid, IAnim
 
         if (this.getAttackTarget() != null)
         {
-            if (this.world.getWorldTime() % 5 == 0)
+            if (this.world.getTotalWorldTime() % 5 == 0)
             {
                 if (!this.getImpregnationEntitiySelector().apply(this.getAttackTarget()))
                 {

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityDrone.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityDrone.java
@@ -113,7 +113,7 @@ public class EntityDrone extends SpeciesXenomorph implements IMaturable
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 if (this.rand.nextInt(3) == 0)
                 {
@@ -152,7 +152,7 @@ public class EntityDrone extends SpeciesXenomorph implements IMaturable
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 if (this.getJellyLevel() < (this.getMaturityLevel() / 2))
                 {
@@ -167,7 +167,7 @@ public class EntityDrone extends SpeciesXenomorph implements IMaturable
         {
             if (this.targetOvamorph == null)
             {
-                if (this.getHive() != null && this.world.getWorldTime() % 10 == 0 && rand.nextInt(3) == 0)
+                if (this.getHive() != null && this.world.getTotalWorldTime() % 10 == 0 && rand.nextInt(3) == 0)
                 {
                     if (this.getJellyLevel() >= 16)
                     {

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMatriarch.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMatriarch.java
@@ -115,7 +115,7 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 this.hive = HiveHandler.instance.getHiveForUUID(this.getUniqueID());
 
@@ -131,7 +131,7 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
     {
         if (this.reproducing)
         {
-            if (this.world.getWorldTime() % (20 * 120) == 0 && this.getJellyLevel() >= OVIPOSITOR_UNHEALTHY_THRESHOLD)
+            if (this.world.getTotalWorldTime() % (20 * 120) == 0 && this.getJellyLevel() >= OVIPOSITOR_UNHEALTHY_THRESHOLD)
             {
                 int ovipositorDist = 10;
                 double rotationYawRadians = Math.toRadians(this.rotationYawHead - 90);
@@ -216,7 +216,7 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
 
                     if (!this.getNavigator().tryMoveToXYZ(closestPoint.x, closestPoint.y, closestPoint.z, 1.55D))
                     {
-                        if (Game.isDevEnvironment() && this.world.getWorldTime() % (20 * 3) == 0)
+                        if (Game.isDevEnvironment() && this.world.getTotalWorldTime() % (20 * 3) == 0)
                         {
                             // System.out.println("Unable to pathfind to closest point, too far: " + this.pathPoints.size() + " Points, " + ((int) closestPoint.distanceFrom(this)) + " Meters, " + closestPoint);
                             // System.out.println(this.pathPoints);
@@ -243,7 +243,7 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
     {
         if (!this.world.isRemote)
         {
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 if (this.getHealth() > this.getMaxHealth() / 4)
                 {
@@ -274,7 +274,7 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
                 this.setDead();
             }
 
-            if (this.world.getWorldTime() % 20 == 0)
+            if (this.world.getTotalWorldTime() % 20 == 0)
             {
                 ArrayList<SpeciesAlien> aliens = (ArrayList<SpeciesAlien>) Entities.getEntitiesInCoordsRange(this.world, SpeciesAlien.class, new Pos(this), 16);
 

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntitySpitter.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntitySpitter.java
@@ -80,7 +80,7 @@ public class EntitySpitter extends SpeciesXenomorph implements IRangedAttackMob
                 EntityAcidProjectile entityacid = new EntityAcidProjectile(this.world, this, living, 1.6F, 14 - attackDamage * 4);
                 entityacid.setDamage(damage * 2.0F + this.rand.nextGaussian() * 0.25D + attackDamage * 0.11F);
                 
-                if (this.world.getWorldTime() % 30 == 0)
+                if (this.world.getTotalWorldTime() % 30 == 0)
                 {
                     this.world.spawnEntity(entityacid);
                 }

--- a/src/main/java/org/avp/entities/living/vardic/EntityDeaconShark.java
+++ b/src/main/java/org/avp/entities/living/vardic/EntityDeaconShark.java
@@ -132,7 +132,7 @@ public class EntityDeaconShark extends SpeciesAlien
     {
         if (this.getAttackTarget() == null || this.getAttackTarget() != null && this.getAttackTarget().isDead || !(this.distanceToTargetLastTick - this.getDistanceSq(this.getAttackTarget()) > 0.1))
         {
-            if (this.world.getWorldTime() % 60 == 0)
+            if (this.world.getTotalWorldTime() % 60 == 0)
             {
                 this.setAttackTarget(this.findTarget());
             }
@@ -195,7 +195,7 @@ public class EntityDeaconShark extends SpeciesAlien
     @Override
     public boolean getCanSpawnHere()
     {
-        if (!(this.posZ > 16 && this.posY <= 64 && this.world.getWorldTime() % 80 == 0))
+        if (!(this.posZ > 16 && this.posY <= 64 && this.world.getTotalWorldTime() % 80 == 0))
         {
             return false;
         }

--- a/src/main/java/org/avp/entities/living/vardic/EntityHammerpede.java
+++ b/src/main/java/org/avp/entities/living/vardic/EntityHammerpede.java
@@ -87,7 +87,7 @@ public class EntityHammerpede extends SpeciesAlien implements IMob
     {
         if (this.getAttackTarget() == null)
         {
-            if (this.world.getWorldTime() % 40 == 0 && this.rand.nextInt(4) == 0)
+            if (this.world.getTotalWorldTime() % 40 == 0 && this.rand.nextInt(4) == 0)
             {
                 if (this.world.getBlockState(new BlockPos((int) this.posX, (int) this.posY, (int) this.posZ)).getBlock() != AliensVsPredator.blocks().blackgoo)
                 {

--- a/src/main/java/org/avp/entities/living/vardic/EntityOctohugger.java
+++ b/src/main/java/org/avp/entities/living/vardic/EntityOctohugger.java
@@ -116,7 +116,7 @@ public class EntityOctohugger extends EntityParasitoid implements IMob, IParasit
         super.onUpdate();
         this.fallDistance = 0;
 
-        if (!this.world.isRemote && this.world.getWorldTime() % 60 == 0 && isHangingLocationStale())
+        if (!this.world.isRemote && this.world.getTotalWorldTime() % 60 == 0 && isHangingLocationStale())
         {
             ArrayList<BlockPos> locations = Blocks.getPositionsInRange((int) this.posX, (int) this.posY, (int) this.posZ, 8);
 

--- a/src/main/java/org/avp/item/ItemIngotLithium.java
+++ b/src/main/java/org/avp/item/ItemIngotLithium.java
@@ -32,7 +32,7 @@ public class ItemIngotLithium extends HookedItem
 
         if (world.isRaining() && world.canSeeSky(entity.getPosition()))
         {
-            if (world.getWorldTime() % 20 == 0)
+            if (world.getTotalWorldTime() % 20 == 0)
             {
                 if (new Random().nextInt(5) == 0)
                 {
@@ -44,11 +44,11 @@ public class ItemIngotLithium extends HookedItem
 
         if (world.getBiome(entity.getPosition()).isHighHumidity())
         {
-            if (world.getWorldTime() % 20 == 0)
+            if (world.getTotalWorldTime() % 20 == 0)
             {
                 if (new Random().nextInt(5) == 0)
                 {
-                    if (world.getWorldTime() % 20 == 0)
+                    if (world.getTotalWorldTime() % 20 == 0)
                     {
                         if (new Random().nextInt(30) == 0)
                         {

--- a/src/main/java/org/avp/tile/TileEntityAssembler.java
+++ b/src/main/java/org/avp/tile/TileEntityAssembler.java
@@ -49,7 +49,7 @@ public class TileEntityAssembler extends TileEntity implements IInventory, ITick
     @Override
     public void update()
     {
-        if (this.getWorld().getWorldTime() % 20 == 0)
+        if (this.getWorld().getTotalWorldTime() % 20 == 0)
         {
             Random rand = new Random();
 

--- a/src/main/java/org/avp/tile/TileEntityBlastdoor.java
+++ b/src/main/java/org/avp/tile/TileEntityBlastdoor.java
@@ -133,7 +133,7 @@ public class TileEntityBlastdoor extends TileEntityElectrical implements IVoltag
 
         if (this.isParent())
         {
-            if (this.isLocked() && !this.isOpen() && this.getWorld().getWorldTime() % 10 == 0)
+            if (this.isLocked() && !this.isOpen() && this.getWorld().getTotalWorldTime() % 10 == 0)
             {
                 int scanRange = 1;
                 List<EntityPlayer> players = world.getEntitiesWithinAABB(EntityPlayer.class, new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1).grow(scanRange * 2, 5, scanRange * 2));

--- a/src/main/java/org/avp/tile/TileEntityCryostasisTube.java
+++ b/src/main/java/org/avp/tile/TileEntityCryostasisTube.java
@@ -40,7 +40,7 @@ public class TileEntityCryostasisTube extends TileEntityElectrical implements IV
         
         if (this.stasisEntity != null && !this.isOperational())
         {
-            if (this.world.getWorldTime() % 100 == 0)
+            if (this.world.getTotalWorldTime() % 100 == 0)
             {
                 if (this.world.rand.nextInt(8) == 0)
                 {

--- a/src/main/java/org/avp/tile/TileEntityElectrical.java
+++ b/src/main/java/org/avp/tile/TileEntityElectrical.java
@@ -394,7 +394,7 @@ public abstract class TileEntityElectrical extends TileEntity implements ITickab
 
     public boolean canArc()
     {
-        if (this.voltage > 600 && this.world.getWorldTime() % 8 == 0)
+        if (this.voltage > 600 && this.world.getTotalWorldTime() % 8 == 0)
         {
             return getNearbyConnectionCount() <= 1;
         }

--- a/src/main/java/org/avp/tile/TileEntityRedstoneFluxGenerator.java
+++ b/src/main/java/org/avp/tile/TileEntityRedstoneFluxGenerator.java
@@ -76,7 +76,7 @@ public class TileEntityRedstoneFluxGenerator extends TileEntityElectrical implem
             this.setVoltage(0);
         }
 
-        if (!this.world.isRemote && this.world.getWorldTime() % 20 == 0)
+        if (!this.world.isRemote && this.world.getTotalWorldTime() % 20 == 0)
         {
             AliensVsPredator.network().sendToAll(new PacketSyncRF(this.getEnergyStored(null), this.pos.getX(), this.pos.getY(), this.pos.getZ()));
         }

--- a/src/main/java/org/avp/tile/TileEntitySolarPanel.java
+++ b/src/main/java/org/avp/tile/TileEntitySolarPanel.java
@@ -18,7 +18,7 @@ public class TileEntitySolarPanel extends TileEntityElectrical implements IVolta
     {
         if (this.world.getWorldTime() < 12300 || this.world.getWorldTime() > 23850)
         {
-            if (this.getWorld().getWorldTime() % (1000 / this.getUpdateFrequency()) == 0)
+            if (this.getWorld().getTotalWorldTime() % (1000 / this.getUpdateFrequency()) == 0)
             {
                 this.setVoltage(120);
             }

--- a/src/main/java/org/avp/tile/TileEntityStasisMechanism.java
+++ b/src/main/java/org/avp/tile/TileEntityStasisMechanism.java
@@ -32,7 +32,7 @@ public class TileEntityStasisMechanism extends TileEntity implements ITickable
     @Override
     public void update()
     {
-        if (this.dummyEntity == null && this.world.getWorldTime() % 20 == 0)
+        if (this.dummyEntity == null && this.world.getTotalWorldTime() % 20 == 0)
         {
             this.dummyEntity = (EntityMechanism) getEntityForUUID(this.world, this.readOnlyDmmyEntityUUID);
 

--- a/src/main/java/org/avp/tile/TileEntityTeslaCoil.java
+++ b/src/main/java/org/avp/tile/TileEntityTeslaCoil.java
@@ -116,7 +116,7 @@ public class TileEntityTeslaCoil extends TileEntityElectrical implements IVoltag
     @Override
     public boolean canArc()
     {
-        if (this.world.getWorldTime() % 2 == 0)
+        if (this.world.getTotalWorldTime() % 2 == 0)
         {
             return true;
         }
@@ -185,7 +185,7 @@ public class TileEntityTeslaCoil extends TileEntityElectrical implements IVoltag
             int rng = 8;
             Pos t = null;
 
-            if (this.sustainArcTimestamp > 0 && world.getWorldTime() - this.sustainArcTimestamp > SUSTAIN_TIME || this.getWorld().getWorldTime() - this.sustainArcTimestamp < 0)
+            if (this.sustainArcTimestamp > 0 && world.getTotalWorldTime() - this.sustainArcTimestamp > SUSTAIN_TIME || this.getWorld().getTotalWorldTime() - this.sustainArcTimestamp < 0)
             {
                 this.sustainArcPos = null;
                 this.sustainArcTimestamp = 0;
@@ -221,7 +221,7 @@ public class TileEntityTeslaCoil extends TileEntityElectrical implements IVoltag
 
                         if (this.sustainArcPos == null)
                         {
-                            this.sustainArcTimestamp = world.getWorldTime();
+                            this.sustainArcTimestamp = world.getTotalWorldTime();
                             this.sustainArcPos = t = t.add(-0.5, -1, -0.5);
                         }
 
@@ -262,7 +262,7 @@ public class TileEntityTeslaCoil extends TileEntityElectrical implements IVoltag
     @SideOnly(Side.CLIENT)
     public void spawnArc(Pos t, float m, Random rand, double dist, Pos origin, double arcWidth)
     {
-        boolean holdArc = sustainArcTimestamp > 0 && this.world.getWorldTime() - sustainArcTimestamp < 1;
+        boolean holdArc = sustainArcTimestamp > 0 && this.world.getTotalWorldTime() - sustainArcTimestamp < 1;
         float targetX = (float) (t.x + (rand.nextFloat() / m) - (rand.nextFloat() / m));
         float targetY = (float) (t.y + 1);
         float targetZ = (float) (t.z + (rand.nextFloat() / m) - (rand.nextFloat() / m));

--- a/src/main/java/org/avp/tile/TileEntityTurret.java
+++ b/src/main/java/org/avp/tile/TileEntityTurret.java
@@ -311,7 +311,7 @@ public class TileEntityTurret extends TileEntityElectrical implements IDataDevic
             }
         }
 
-        if (!this.world.isRemote && this.world.getWorldTime() % 10 == 0)
+        if (!this.world.isRemote && this.world.getTotalWorldTime() % 10 == 0)
         {
             if (this.getTargetEntity() == null || this.getTargetEntity() != null && !this.canTarget(targetEntity))
             {
@@ -339,7 +339,7 @@ public class TileEntityTurret extends TileEntityElectrical implements IDataDevic
             {
                 AliensVsPredator.network().sendToAll(new PacketTurretTargetUpdate(this));
 
-                if (world.getWorldInfo().getWorldTime() % fireRate == 0L && this.rot.yaw == this.focrot.yaw)
+                if (world.getWorldInfo().getWorldTotalTime() % fireRate == 0L && this.rot.yaw == this.focrot.yaw)
                 {
                     if (curAmmo-- > 0)
                     {
@@ -405,7 +405,7 @@ public class TileEntityTurret extends TileEntityElectrical implements IDataDevic
 
     public void updateAmmunitionCount()
     {
-        if (world.getWorldInfo().getWorldTime() % 8L == 0L)
+        if (world.getWorldInfo().getWorldTotalTime() % 8L == 0L)
         {
             this.roundsMax = (9 * 64);
             this.rounds = 0;

--- a/src/main/java/org/avp/world/capabilities/IOrganism.java
+++ b/src/main/java/org/avp/world/capabilities/IOrganism.java
@@ -181,7 +181,7 @@ public interface IOrganism
         {
             World world = living.world;
 
-            if (!world.isRemote && world.getWorldTime() % 60 == 0)
+            if (!world.isRemote && world.getTotalWorldTime() % 60 == 0)
             {
                 this.syncWithClients(living);
             }
@@ -212,7 +212,7 @@ public interface IOrganism
                     {
                         organism.setHeartRate(60 + (250 - (timeLeft * 250 / (30 * 20))));
 
-                        if (world.getWorldTime() % 10 == 0)
+                        if (world.getTotalWorldTime() % 10 == 0)
                         {
                             this.syncWithClients(living);
                         }

--- a/src/main/java/org/avp/world/hives/XenomorphHive.java
+++ b/src/main/java/org/avp/world/hives/XenomorphHive.java
@@ -148,7 +148,7 @@ public class XenomorphHive
             this.dimensionId = this.getQueen().world.provider.getDimension();
         }
 
-        if (world.getWorldTime() % (20 * 5) == 0)
+        if (world.getTotalWorldTime() % (20 * 5) == 0)
             aliens.entrySet().removeIf(e -> e.getValue() == null || e.getValue().isDead);
     }
 


### PR DESCRIPTION
Another rolling out of some improvements to the mod. General optimizations and fixes:
- The material handler now does no looping through all loaded entities in the game. Previously, it was looping 2 times through all loaded entities on the client-side and once on the server-side every tick.
- SpeciesAlien entities now only have drops created when it is expected for them to have a drop. Previously the drop was created prior to a check that used it.
- Fixed logical scheduling of tasks using world time. Previously, the world time (0 - 24000) was used in calculations to determine when certain logic should fire. This would cause said logic to not fire if the day/night cycle was paused, or for a very brief time when the world time was changed by the player via commands or sleeping.
- Removed cloning of biome filter ArrayLists during mod initialization.