### PR TITLE
Stun baton fixes and xenomorph jelly enhancements.

### DIFF
--- a/src/main/java/org/avp/entities/ai/alien/EntityAIFindJelly.java
+++ b/src/main/java/org/avp/entities/ai/alien/EntityAIFindJelly.java
@@ -1,0 +1,91 @@
+package org.avp.entities.ai.alien;
+
+import java.util.ArrayList;
+
+import org.avp.AliensVsPredator;
+import org.avp.entities.living.species.SpeciesXenomorph;
+
+import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.World;
+
+public class EntityAIFindJelly extends EntityAIBase
+{
+
+    private SpeciesXenomorph xenomorph;
+    private World            world;
+    private boolean          hasPickedUpJelly;
+
+    public EntityAIFindJelly(SpeciesXenomorph xenomorph)
+    {
+        super();
+        this.xenomorph = xenomorph;
+        this.world = xenomorph.world;
+        this.hasPickedUpJelly = false;
+    }
+
+    @Override
+    public boolean shouldExecute()
+    {
+        return xenomorph.getAttackTarget() == null;
+    }
+
+    @Override
+    public void startExecuting()
+    {
+        super.startExecuting();
+    }
+
+    @Override
+    public boolean shouldContinueExecuting()
+    {
+        return xenomorph.getAttackTarget() == null && !this.hasPickedUpJelly;
+    }
+
+    @Override
+    public void resetTask()
+    {
+        super.resetTask();
+        this.hasPickedUpJelly = false;
+    }
+
+    @Override
+    public void updateTask()
+    {
+        super.updateTask();
+        int range = 8;
+        ArrayList<EntityItem> entityItemList = (ArrayList<EntityItem>) world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(this.xenomorph.getPosition().add(-range, -8, -range), this.xenomorph.getPosition().add(range, 8, range)));
+
+        if (!entityItemList.isEmpty())
+        {
+            EntityItem randomJelly = entityItemList.get(this.xenomorph.getRNG().nextInt(entityItemList.size()));
+
+            if (!randomJelly.cannotPickup())
+            {
+                ItemStack stack = randomJelly.getItem();
+
+                if (stack.getItem() == AliensVsPredator.items().itemRoyalJelly)
+                {
+                    if (this.xenomorph.canMoveToJelly() && this.xenomorph.isDependantOnHive())
+                    {
+                        this.xenomorph.getNavigator().setPath(this.xenomorph.getNavigator().getPathToEntityLiving(randomJelly), 1);
+                    }
+
+                    if (this.xenomorph.getDistanceSq(randomJelly) <= 1)
+                    {
+                        this.onPickupJelly(randomJelly);
+                        this.hasPickedUpJelly = true;
+                    }
+                }
+            }
+        }
+    }
+
+    private void onPickupJelly(EntityItem entityItem)
+    {
+        this.xenomorph.setJellyLevel(this.xenomorph.getJellyLevel() + (entityItem.getItem().getCount() * 100));
+        entityItem.setDead();
+    }
+}

--- a/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
@@ -160,40 +160,6 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
         this.setDead();
     }
 
-    protected void findRoyalJelly()
-    {
-        if (!this.world.isRemote && this.ticksExisted % 40 == 0)
-        {
-            int range = 8;
-            ArrayList<EntityItem> entityItemList = (ArrayList<EntityItem>) world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(this.getPosition().add(-range, -8, -range), this.getPosition().add(range, 8, range)));
-
-            for (EntityItem entityItem : entityItemList)
-            {
-                if (!entityItem.cannotPickup())
-                {
-                    ItemStack stack = entityItem.getItem();
-
-                    if (stack.getItem() == AliensVsPredator.items().itemRoyalJelly)
-                    {
-                        if (this.canMoveToJelly() && this.isDependant)
-                        {
-                            this.getNavigator().setPath(this.getNavigator().getPathToEntityLiving(entityItem), 1);
-                        }
-
-                        if (this.getDistanceSq(entityItem) <= 1)
-                        {
-                            this.onPickupJelly(entityItem);
-                        }
-                        break;
-                    }
-                }
-            }
-
-            entityItemList.clear();
-            entityItemList = null;
-        }
-    }
-
     public UUID getHiveSignature()
     {
         return this.signature;
@@ -261,7 +227,6 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
         }
 
         this.identifyHive();
-        this.findRoyalJelly();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/SpeciesXenomorph.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesXenomorph.java
@@ -3,6 +3,7 @@ package org.avp.entities.living.species;
 import org.avp.DamageSources;
 import org.avp.EntityItemDrops;
 import org.avp.entities.ai.EntityAICustomAttackOnCollide;
+import org.avp.entities.ai.alien.EntityAIFindJelly;
 import org.avp.entities.ai.alien.EntitySelectorXenomorph;
 import org.avp.entities.living.species.xenomorphs.EntityMatriarch;
 
@@ -53,10 +54,11 @@ public abstract class SpeciesXenomorph extends SpeciesAlien implements IMob
     {
         this.tasks.addTask(0, new EntityAISwimming(this));
         this.tasks.addTask(1, new EntityAIWander(this, 0.8D));
-        this.tasks.addTask(2, new EntityAICustomAttackOnCollide(this, EntityLiving.class, 1.0D, false));
-        this.tasks.addTask(2, new EntityAICustomAttackOnCollide(this, EntityPlayer.class, 1.0D, false));
+        this.tasks.addTask(1, new EntityAIFindJelly(this));
         this.tasks.addTask(2, new EntityAIWatchClosest(this, EntityLivingBase.class, 16F));
-        this.tasks.addTask(3, new EntityAILeapAtTarget(this, 0.6F));
+        this.tasks.addTask(3, new EntityAICustomAttackOnCollide(this, EntityLiving.class, 1.0D, false));
+        this.tasks.addTask(3, new EntityAICustomAttackOnCollide(this, EntityPlayer.class, 1.0D, false));
+        this.tasks.addTask(5, new EntityAILeapAtTarget(this, 0.6F));
         this.targetTasks.addTask(0, new EntityAIHurtByTarget(this, true));
         this.targetTasks.addTask(1, new EntityAINearestAttackableTarget<EntityLiving>(this, EntityLiving.class, 0, false, false, EntitySelectorXenomorph.instance));
         this.targetTasks.addTask(1, new EntityAINearestAttackableTarget<EntityPlayer>(this, EntityPlayer.class, 0, false, false, EntitySelectorXenomorph.instance));

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityDracomorph.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityDracomorph.java
@@ -220,10 +220,4 @@ public class EntityDracomorph extends SpeciesAlien implements IMob, IHost
     {
         ;
     }
-    
-    @Override
-    protected void findRoyalJelly()
-    {
-        ;
-    }
 }

--- a/src/main/java/org/avp/item/ItemStunBaton.java
+++ b/src/main/java/org/avp/item/ItemStunBaton.java
@@ -39,7 +39,9 @@ public class ItemStunBaton extends ItemSword
     {
         if (hasCharge(player.world, player))
         {
-            addArcEffect(player, entity);
+            if(player.world.isRemote)
+                addArcEffect(player, entity);
+            
             Sounds.WEAPON_STUNBATON.playSound(entity);
 
             if (entity instanceof EntityLiving)


### PR DESCRIPTION
- Stun batons are now fixed server-side. They make sound and deal damage properly.
- Improved how xenomorphs search for jelly. Their jelly pickup and search time is now instantaneous, no longer interrupts combat AI, and xenomorphs now go for random jelly stacks instead of clustering up around the same ones.