### PR TITLE
Introduced additional blood fx setting, fixed queen jelly finding AI, and some other small fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ repositories {
 def version_minecraft="1.12.2"
 def version_forge="14.23.5.2847"
 def version_mappings="stable_39"
-def mdxversion="3.0.0.21"
+def mdxversion="3.0.0.23"
 def curseforge_id="221641"
 def curseforge_release_type="release"
 def curseforge_api_key=project.ext.properties.curseforge_api_key == null ? "00000-00000-00000-00000-00000" : project.ext.properties.curseforge_api_key

--- a/src/main/java/org/avp/Settings.java
+++ b/src/main/java/org/avp/Settings.java
@@ -77,12 +77,14 @@ public class Settings implements IPreInitEvent, IFlexibleConfiguration
         private final String                   CATEGORY_GRAPHICS = "graphics";
 
         private ConfigSettingGraphics          hiveTessellation;
+        private ConfigSettingGraphics          bloodDetails;
         private ConfigSettingBoolean           bloodEffects;
 
         public void load(Configuration configuration)
         {
             this.configuration = configuration;
             this.hiveTessellation = new ConfigSettingGraphics(this, configuration.get(CATEGORY_GRAPHICS, "hive_tessellation", GraphicsSetting.ULTRA.ordinal(), "The visual complexity and detail of xenomorph hives."));
+            this.bloodDetails = new ConfigSettingGraphics(this, configuration.get(CATEGORY_GRAPHICS, "blood_details", GraphicsSetting.ULTRA.ordinal(), "Sets the amount of blood particles and how long they last."));
             this.bloodEffects = new ConfigSettingBoolean(this, configuration.get(CATEGORY_GRAPHICS, "blood_fx", true, "Turns blood particle effects on or off."));
         }
 
@@ -94,6 +96,11 @@ public class Settings implements IPreInitEvent, IFlexibleConfiguration
         public ConfigSettingGraphics hiveTessellation()
         {
             return this.hiveTessellation;
+        }
+
+        public ConfigSettingGraphics bloodDetails()
+        {
+            return this.bloodDetails;
         }
 
         public ConfigSettingBoolean bloodFX()

--- a/src/main/java/org/avp/client/input/handlers/InputHandlerFirearm.java
+++ b/src/main/java/org/avp/client/input/handlers/InputHandlerFirearm.java
@@ -7,6 +7,8 @@ import org.avp.packets.server.PacketReloadFirearm;
 
 import com.asx.mdx.lib.util.Game;
 
+import net.minecraft.item.Item;
+
 public class InputHandlerFirearm implements IInputHandler
 {
     public static final InputHandlerFirearm instance   = new InputHandlerFirearm();
@@ -18,10 +20,23 @@ public class InputHandlerFirearm implements IInputHandler
         if (Game.minecraft().player != null)
         {
             this.lastReload++;
+            
+            Item mainHand = Game.minecraft().player.getHeldItemMainhand().getItem();
+            Item offHand = Game.minecraft().player.getHeldItemOffhand().getItem();
 
-            if (Game.minecraft().inGameHasFocus && Game.minecraft().player.inventory.getCurrentItem() != null && Game.minecraft().player.inventory.getCurrentItem().getItem() instanceof ItemFirearm)
+            if (Game.minecraft().inGameHasFocus && mainHand != null && mainHand instanceof ItemFirearm)
             {
-                ItemFirearm fireArm = (ItemFirearm) Game.minecraft().player.inventory.getCurrentItem().getItem();
+                ItemFirearm fireArm = (ItemFirearm) mainHand;
+
+                if (AliensVsPredator.keybinds().specialSecondary.isPressed() && this.lastReload > fireArm.getProfile().getReloadTime())
+                {
+                    this.lastReload = 0;
+                    AliensVsPredator.network().sendToServer(new PacketReloadFirearm());
+                }
+            }
+            else if (Game.minecraft().inGameHasFocus && offHand != null && offHand instanceof ItemFirearm)
+            {
+            	ItemFirearm fireArm = (ItemFirearm) offHand;
 
                 if (AliensVsPredator.keybinds().specialSecondary.isPressed() && this.lastReload > fireArm.getProfile().getReloadTime())
                 {

--- a/src/main/java/org/avp/client/render/TacticalHUDRenderEvent.java
+++ b/src/main/java/org/avp/client/render/TacticalHUDRenderEvent.java
@@ -11,6 +11,7 @@ import org.avp.AliensVsPredator;
 import org.avp.client.gui.GuiTacticalHUDSettings;
 import org.avp.client.render.wavegraph.Wavegraph;
 import org.avp.client.render.wavegraph.ekg.Electrocardiogram;
+import org.avp.entities.living.species.EntityParasitoid;
 import org.avp.world.capabilities.IOrganism.Organism;
 import org.avp.world.capabilities.IOrganism.Provider;
 import org.avp.world.capabilities.ISpecialPlayer.SpecialPlayer;
@@ -81,6 +82,10 @@ public class TacticalHUDRenderEvent
                     }
 
                     trackedEntities = (ArrayList<EntityLivingBase>) Entities.getEntitiesInCoordsRange(Game.minecraft().player.world, EntityLivingBase.class, new Pos(Game.minecraft().player), 30, 30);
+                    
+                    trackedEntities.removeIf(e -> {
+                    	return (e instanceof EntityParasitoid) && !((EntityParasitoid)e).isFertile();
+                    });
                 }
 
                 if (trackedEntities != null)

--- a/src/main/java/org/avp/client/render/items/ItemFirearmRenderer.java
+++ b/src/main/java/org/avp/client/render/items/ItemFirearmRenderer.java
@@ -1,0 +1,31 @@
+package org.avp.client.render.items;
+
+import org.avp.item.ItemFirearm;
+
+import com.asx.mdx.lib.client.util.ItemRenderer;
+import com.asx.mdx.lib.client.util.models.MapModelTexture;
+import com.asx.mdx.lib.client.util.models.Model;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+
+abstract class ItemFirearmRenderer<T extends Model<?>> extends ItemRenderer<T>
+{
+	public ItemFirearmRenderer(MapModelTexture<T> model)
+	{
+		super(model);
+	}
+	
+	public boolean isDualWielding(EntityLivingBase entity)
+	{
+		if(!(entity instanceof EntityPlayer))
+			return false;
+		
+		EntityPlayer player = (EntityPlayer) entity;
+		
+		if(player.getHeldItemMainhand().getItem() instanceof ItemFirearm && player.getHeldItemOffhand().getItem() instanceof ItemFirearm)
+			return true;
+		
+		return false;
+	}
+}

--- a/src/main/java/org/avp/client/render/items/RenderItem88MOD4.java
+++ b/src/main/java/org/avp/client/render/items/RenderItem88MOD4.java
@@ -13,7 +13,7 @@ import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformT
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-public class RenderItem88MOD4 extends ItemRenderer<Model88MOD4>
+public class RenderItem88MOD4 extends ItemFirearmRenderer<Model88MOD4>
 {
     public RenderItem88MOD4()
     {
@@ -37,7 +37,7 @@ public class RenderItem88MOD4 extends ItemRenderer<Model88MOD4>
             float glScale = 1F;
             OpenGL.translate(0.25F, 0.16F, -0.5F);
 
-            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
             {
                 OpenGL.translate(-0.77F, 0.25F, 0.35F);
             }

--- a/src/main/java/org/avp/client/render/items/RenderItemAK47.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemAK47.java
@@ -16,7 +16,7 @@ import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformT
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-public class RenderItemAK47 extends ItemRenderer<ModelAK47>
+public class RenderItemAK47 extends ItemFirearmRenderer<ModelAK47>
 {
     public RenderItemAK47()
     {
@@ -48,7 +48,7 @@ public class RenderItemAK47 extends ItemRenderer<ModelAK47>
         {
             OpenGL.translate(1F, 0.2F, 0.2F);
 
-            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
             {
                 OpenGL.translate(-1.735F, 0.24F, 0.8F);
             }

--- a/src/main/java/org/avp/client/render/items/RenderItemM240ICU.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemM240ICU.java
@@ -16,7 +16,7 @@ import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformT
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-public class RenderItemM240ICU extends ItemRenderer<ModelM240ICU>
+public class RenderItemM240ICU extends ItemFirearmRenderer<ModelM240ICU>
 {
     public RenderItemM240ICU()
     {
@@ -51,7 +51,7 @@ public class RenderItemM240ICU extends ItemRenderer<ModelM240ICU>
         {
             OpenGL.translate(0F, 0.15F, -0.4F);
 
-            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
             {
                 OpenGL.translate(-0.6495F, 0F, 0F);
             }

--- a/src/main/java/org/avp/client/render/items/RenderItemM4.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemM4.java
@@ -13,7 +13,7 @@ import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformT
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-public class RenderItemM4 extends ItemRenderer<ModelM4>
+public class RenderItemM4 extends ItemFirearmRenderer<ModelM4>
 {
     public RenderItemM4()
     {
@@ -46,7 +46,7 @@ public class RenderItemM4 extends ItemRenderer<ModelM4>
             float glScale = 1.0F;
             OpenGL.translate(0F, 0.85F, 0F);
 
-            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
             {
                 OpenGL.translate(-0.8095F, 0.165F, 0.4F);
             }

--- a/src/main/java/org/avp/client/render/items/RenderItemM41A.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemM41A.java
@@ -22,7 +22,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
-public class RenderItemM41A extends ItemRenderer<ModelM41A>
+public class RenderItemM41A extends ItemFirearmRenderer<ModelM41A>
 {
     private RenderMotionTrackerScreen motionTracker = new RenderMotionTrackerScreen();
 
@@ -59,7 +59,7 @@ public class RenderItemM41A extends ItemRenderer<ModelM41A>
         {
             OpenGL.translate(1F, 1.25F, -0.3F);
 
-            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
             {
                 OpenGL.translate(-1.16F, -0.095F, 0.52F);
             }

--- a/src/main/java/org/avp/client/render/items/RenderItemNostromoFlamethrower.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemNostromoFlamethrower.java
@@ -14,7 +14,7 @@ import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformT
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-public class RenderItemNostromoFlamethrower extends ItemRenderer<ModelSevastopolFlamethrower>
+public class RenderItemNostromoFlamethrower extends ItemFirearmRenderer<ModelSevastopolFlamethrower>
 {
     public RenderItemNostromoFlamethrower()
     {
@@ -48,7 +48,7 @@ public class RenderItemNostromoFlamethrower extends ItemRenderer<ModelSevastopol
         {
             OpenGL.translate(0F, 0.35F, -0.9F);
 
-            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+            if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
             {
                 OpenGL.translate(-0.5595F, 0F, 0F);
             }

--- a/src/main/java/org/avp/client/render/items/RenderItemSniper.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemSniper.java
@@ -14,7 +14,7 @@ import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-public class RenderItemSniper extends ItemRenderer<ModelSniper>
+public class RenderItemSniper extends ItemFirearmRenderer<ModelSniper>
 {
     private float defaultFOV = Game.minecraft().gameSettings.getOptionFloatValue(GameSettings.Options.FOV);
 
@@ -43,7 +43,7 @@ public class RenderItemSniper extends ItemRenderer<ModelSniper>
                     this.defaultFOV = Game.minecraft().gameSettings.getOptionFloatValue(GameSettings.Options.FOV);
                 }
 
-                if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+                if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
                 {
                     Game.minecraft().gameSettings.setOptionFloatValue(GameSettings.Options.FOV, 9F);
                 }
@@ -71,7 +71,7 @@ public class RenderItemSniper extends ItemRenderer<ModelSniper>
         float glScale = 1.5F;
         OpenGL.translate(0F, 0.35F, -0.3F);
 
-        if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus)
+        if (Mouse.isButtonDown(0) && Game.minecraft().inGameHasFocus && !isDualWielding(entity))
         {
             this.getModel().getModel().setFirstPerson(true);
             OpenGL.translate(-0.5125F, 0.095F, 0.62F);

--- a/src/main/java/org/avp/client/render/items/RenderItemStunBaton.java
+++ b/src/main/java/org/avp/client/render/items/RenderItemStunBaton.java
@@ -23,7 +23,7 @@ public class RenderItemStunBaton extends ItemRenderer<ModelStunBaton>
     {
         float glScale = 1.1F;
         OpenGL.scale(glScale, glScale, glScale);
-        OpenGL.translate(0F, 0.1F, 0.1F);
+        OpenGL.translate(0F, 0.12F, 0.1F);
         OpenGL.rotate(180.0F, 1.0F, 0.0F, 1.0F);
         OpenGL.rotate(-90.0F, 0.0F, 1.0F, 0.0F);
         this.getModel().draw();

--- a/src/main/java/org/avp/client/render/wavegraph/ekg/Electrocardiogram.java
+++ b/src/main/java/org/avp/client/render/wavegraph/ekg/Electrocardiogram.java
@@ -86,11 +86,13 @@ public class Electrocardiogram extends Wavegraph
         flatlineY = (y + height - flatlineHeight) - (height / 2);
 
         OpenGL.enableBlend();
+        OpenGL.enableAlphaTest();
         Draw.drawRect(x, y, width, height, newdata ? backlightColor : backgroundColor);
         this.drawBPMString(partialTicks);
         OpenGL.disableTexture2d();
         this.drawRecords(partialTicks);
         OpenGL.enableTexture2d();
+        OpenGL.disableAlphaTest();
         OpenGL.disableBlend();
     }
 

--- a/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
+++ b/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
@@ -335,7 +335,7 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
     @Override
     public boolean attackEntityFrom(DamageSource source, float attackStrength)
     {
-    	if(source == DamageSource.IN_WALL && this.isAttachedToHost())
+    	if(source == DamageSource.IN_WALL && (this.isAttachedToHost() || !this.isFertile()))
     		return false;
     	
         return super.attackEntityFrom(source, attackStrength);

--- a/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
+++ b/src/main/java/org/avp/entities/living/species/EntityParasitoid.java
@@ -335,6 +335,9 @@ public class EntityParasitoid extends SpeciesAlien implements IMob, IParasitoid
     @Override
     public boolean attackEntityFrom(DamageSource source, float attackStrength)
     {
+    	if(source == DamageSource.IN_WALL && this.isAttachedToHost())
+    		return false;
+    	
         return super.attackEntityFrom(source, attackStrength);
     }
 

--- a/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
+++ b/src/main/java/org/avp/entities/living/species/SpeciesAlien.java
@@ -116,7 +116,7 @@ public abstract class SpeciesAlien extends EntityMob implements IMob, IRoyalOrga
     @Override
     public boolean attackEntityFrom(DamageSource source, float amount)
     {
-        if(!this.world.isRemote && this.getHealth() > amount && !source.isProjectile() && !source.isMagicDamage() && (this.getMaxHealth() * 0.25 <= amount || this.rand.nextInt(30) == 0))
+        if(!this.world.isRemote && this.getHealth() > amount && source != DamageSource.IN_WALL && !source.isProjectile() && !source.isMagicDamage() && (this.getMaxHealth() * 0.25 <= amount || this.rand.nextInt(30) == 0))
             this.spawnAcidPool();
         return super.attackEntityFrom(source, amount);
     }

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMatriarch.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMatriarch.java
@@ -7,6 +7,7 @@ import org.avp.AliensVsPredator;
 import org.avp.ItemHandler;
 import org.avp.client.Sounds;
 import org.avp.entities.ai.EntityAICustomAttackOnCollide;
+import org.avp.entities.ai.alien.EntityAIFindJelly;
 import org.avp.entities.ai.alien.EntitySelectorXenomorph;
 import org.avp.entities.living.species.SpeciesAlien;
 import org.avp.entities.living.species.SpeciesXenomorph;
@@ -107,6 +108,7 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
         {
             this.tasks.addTask(0, new EntityAISwimming(this));
             this.tasks.addTask(1, new EntityAIWander(this, 0.8D));
+            this.tasks.addTask(2, new EntityAIFindJelly(this));
             this.tasks.addTask(4, new EntityAICustomAttackOnCollide(this, 0.8D, true));
             this.targetTasks.addTask(0, new EntityAINearestAttackableTarget(this, EntityLiving.class, 0, false, false, EntitySelectorXenomorph.instance));
             this.targetTasks.addTask(1, new EntityAIHurtByTarget(this, true));

--- a/src/main/java/org/avp/item/ItemFirearm.java
+++ b/src/main/java/org/avp/item/ItemFirearm.java
@@ -325,6 +325,24 @@ public class ItemFirearm extends HookedItem
                 }
             }
         }
+        
+        for (ItemStack itemstack : player.inventory.offHandInventory)
+        {
+            if (itemstack != null && itemstack.getItem() instanceof ItemAmmunition)
+            {
+                ItemAmmunition ammunition = (ItemAmmunition) itemstack.getItem();
+
+                if (ammunition.getClassification() == firearm.getClassification())
+                {
+                    if (!simulate)
+                    {
+                        Inventories.consumeItem(player, ammunition);
+                    }
+
+                    return true;
+                }
+            }
+        }
 
         return false;
     }

--- a/src/main/java/org/avp/packets/client/PacketAmmoUpdate.java
+++ b/src/main/java/org/avp/packets/client/PacketAmmoUpdate.java
@@ -5,6 +5,7 @@ import org.avp.item.ItemFirearm;
 import com.asx.mdx.lib.util.Game;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -43,7 +44,16 @@ public class PacketAmmoUpdate implements IMessage, IMessageHandler<PacketAmmoUpd
             @Override
             public void run()
             {
-                ((ItemFirearm) Game.minecraft().player.inventory.getCurrentItem().getItem()).setAmmoCount(packet.ammo);
+            	EntityPlayer player = ctx.getServerHandler().player;
+
+                if (player != null && player.getHeldItemMainhand() != null && player.getHeldItemMainhand().getItem() instanceof ItemFirearm)
+                {
+                    ((ItemFirearm) player.getHeldItemMainhand().getItem()).setAmmoCount(packet.ammo);
+                }
+                else if (player != null && player.getHeldItemOffhand() != null && player.getHeldItemOffhand().getItem() instanceof ItemFirearm)
+                {
+                	((ItemFirearm) player.getHeldItemOffhand().getItem()).setAmmoCount(packet.ammo);
+                }
             }
         });
         return null;

--- a/src/main/java/org/avp/packets/server/PacketReloadFirearm.java
+++ b/src/main/java/org/avp/packets/server/PacketReloadFirearm.java
@@ -37,9 +37,13 @@ public class PacketReloadFirearm implements IMessage, IMessageHandler<PacketRelo
             {
                 EntityPlayer player = ctx.getServerHandler().player;
 
-                if (player != null && player.inventory != null && player.inventory.getCurrentItem() != null && player.inventory.getCurrentItem().getItem() instanceof ItemFirearm)
+                if (player != null && player.getHeldItemMainhand() != null && player.getHeldItemMainhand().getItem() instanceof ItemFirearm)
                 {
-                    ((ItemFirearm) player.inventory.getCurrentItem().getItem()).reload(ctx.getServerHandler().player);
+                    ((ItemFirearm) player.getHeldItemMainhand().getItem()).reload(ctx.getServerHandler().player);
+                }
+                else if (player != null && player.getHeldItemOffhand() != null && player.getHeldItemOffhand().getItem() instanceof ItemFirearm)
+                {
+                	((ItemFirearm) player.getHeldItemOffhand().getItem()).reload(ctx.getServerHandler().player);
                 }
             }
         });

--- a/src/main/java/org/avp/tile/TileEntitySolarPanel.java
+++ b/src/main/java/org/avp/tile/TileEntitySolarPanel.java
@@ -3,6 +3,8 @@ package org.avp.tile;
 import org.avp.api.power.IVoltageProvider;
 
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.EnumSkyBlock;
 
 
 
@@ -16,11 +18,21 @@ public class TileEntitySolarPanel extends TileEntityElectrical implements IVolta
     @Override
     public void update()
     {
-        if (this.world.getWorldTime() < 12300 || this.world.getWorldTime() > 23850)
+        if (this.world.provider.hasSkyLight())
         {
-            if (this.getWorld().getTotalWorldTime() % (1000 / this.getUpdateFrequency()) == 0)
+            if (this.world.getTotalWorldTime() % (1000 / this.getUpdateFrequency()) == 0)
             {
-                this.setVoltage(120);
+                int i = this.world.getLightFor(EnumSkyBlock.SKY, pos) - this.world.getSkylightSubtracted();
+                float f = this.world.getCelestialAngleRadians(1.0F);
+
+                if (i > 0)
+                {
+                    float f1 = f < (float)Math.PI ? 0.0F : ((float)Math.PI * 2F);
+                    f = f + (f1 - f) * 0.2F;
+                    i = Math.round((float)i * MathHelper.cos(f));
+                }
+
+				this.setVoltage(MathHelper.clamp(i*10, 0, 120));
             }
         }
         else

--- a/src/main/java/org/avp/world/capabilities/IOrganism.java
+++ b/src/main/java/org/avp/world/capabilities/IOrganism.java
@@ -237,7 +237,7 @@ public interface IOrganism
 
         public void syncWithClients(EntityLivingBase living)
         {
-            if (living != null)
+            if (living != null && !living.world.isRemote)
                 AliensVsPredator.network().sendToAll(new OrganismClientSync(living.getEntityId(), (NBTTagCompound) Provider.CAPABILITY.getStorage().writeNBT(Provider.CAPABILITY, this, null)));
         }
 


### PR DESCRIPTION
Another batch of fixes. Here's the most notable stuff:
- Introduced a blood FX setting to crank down the number of blood particles spawned and how long they last. This gives lower-end users the option to not have their CPU cry from the gore.
- Queens now find jelly properly, again. Clever girl...
- Numerous ammo glitches have been stamped out. This includes:
-- Ammo rounds held in the player's offhand being infinite.
-- Weapons in the offhand not consuming ammo from the main inventory.
--  Ammo reloading not doing anything while dual wielding weapons.
-- Ammo reloading not actually setting the player's ammunition when single or dual wielding weapons.
- AvP now requires MDXLib 3.0.0.23, since that version has item consumption fixes among other things.

The other stuff consists of fixes for issues that were not as severe:
- Aliens no longer bleed from suffocation damage.
- Fixed NullPointerExceptions being thrown when an entity was facehugged on a server.
- Parasitoids no longer suffocate while attached to a host.
- Players no longer firmly grasp the stun baton to the point where it renders right through their arm.
- Solar panels now require sunlight for energy. No more underground solar panel farms.
- Players can no longer aim both weapons they were dual wielding and defy the law of space by having them fuse together.
- Tactical helmet wavegraphs now have proper alpha settings on them, so text in the background isn't obstructed.