### PR TITLE
Fix broken Xeno AI while in hives

### DIFF
--- a/src/main/java/org/avp/entities/ai/alien/EntityAIShareJelly.java
+++ b/src/main/java/org/avp/entities/ai/alien/EntityAIShareJelly.java
@@ -20,7 +20,7 @@ public class EntityAIShareJelly extends EntityAIBase
     @Override
     public boolean shouldExecute()
     {
-        return this.xenomorph.getJellyLevel() > 0 && xenomorph.getHive() != null;
+        return this.xenomorph.getJellyLevel() > 0 && xenomorph.getHive() != null && xenomorph.getAttackTarget() == null;
     }
 
     @Override


### PR DESCRIPTION
Fixes bugged Xeno AI in hives as they prioritized the jelly sharing task over attacking targets, which meant none attacked. 