### PR TITLE
Cleaned up alien AI initialization.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
-        maven {
-            name = "forge"
-            url = "http://files.minecraftforge.net/maven" 
-        }
+    	mavenCentral()
+        maven { url = "https://maven.minecraftforge.net/" }
         maven {
             url = "https://oss.sonatype.org/content/groups/public"
         }
@@ -13,7 +10,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath ('com.anatawa12.forge:ForgeGradle:2.3-1.0.+') {
+        	changing = true
+        }
         classpath 'org.ajoberstar:gradle-git:0.10.1'
         classpath "gradle.plugin.com.matthewprenger:CurseGradle:1.1.0"
     }
@@ -25,7 +24,7 @@ plugins {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'com.matthewprenger.cursegradle'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 configurations {
     deployerJars
@@ -35,6 +34,7 @@ repositories {
     maven {
         name = "aliensvspredator"
         url = "http://maven.aliensvspredator.org/"
+        allowInsecureProtocol = true
     }
 }
 
@@ -73,8 +73,8 @@ println "Minecraft Development Library X ${mdxversion}"
 
 dependencies {
     deployerJars 'org.apache.maven.wagon:wagon-ftp:2.2'
-    compile "com.asx:mdxlib:${mdxversion}:deobf"
-    compile fileTree(dir: 'lib', includes: ['*.jar'])
+    implementation "com.asx:mdxlib:${mdxversion}:deobf"
+    implementation fileTree(dir: 'lib', includes: ['*.jar'])
 }
 
 jar {
@@ -132,22 +132,48 @@ idea {
         inheritOutputDirs = true 
     }
 }
-task("publishToMaven", dependsOn:"build") {
-    description = "Uploads the artifacts generated during the build process to the aliensvspredator maven repository"
 
-    uploadArchives {
-        repositories.mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: "ftp://maven.aliensvspredator.org") {
-                authentication(userName: mavenUsername, password: mavenPassword)
-            }
-            
-            pom.project {
-        		properties {
-            		forgeVersion = version_minecraft
-	            	mcVersion = minecraft.version
-            	}
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            pom {
+                properties = [
+                    forgeVersion: version_minecraft,
+                    mcVersion: minecraft.version
+                ]
             }
         }
     }
+
+    repositories {
+        maven {
+            credentials {
+                username mavenUsername
+                password mavenPassword
+            }
+            url = "ftp://maven.aliensvspredator.org"
+        }
+    }
 }
+
+//task("publishToMaven", dependsOn:"build") {
+//    description = "Uploads the artifacts generated during the build process to the aliensvspredator maven repository"
+//
+//    uploadArchives {
+//        repositories.mavenDeployer {
+//            configuration = configurations.deployerJars
+//            repository(url: "ftp://maven.aliensvspredator.org") {
+//                authentication(userName: mavenUsername, password: mavenPassword)
+//            }
+//
+//            pom.project {
+//        		properties {
+//            		forgeVersion = version_minecraft
+//	            	mcVersion = minecraft.version
+//            	}
+//            }
+//        }
+//    }
+//}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityBatXeno.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityBatXeno.java
@@ -13,7 +13,6 @@ public class EntityBatXeno extends SpeciesXenomorph
     public EntityBatXeno(World world)
     {
         super(world);
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityBoiler.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityBoiler.java
@@ -19,10 +19,6 @@ public class EntityBoiler extends SpeciesXenomorph
         super(world);
         this.experienceValue = 275;
         this.setSize(1.0F, 3.0F);
-        
-        
-        this.tasks.addTask(0, new EntityAISwimming(this));
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityDrone.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityDrone.java
@@ -47,9 +47,6 @@ public class EntityDrone extends SpeciesXenomorph implements IMaturable
         blockBlacklist.add(Blocks.AIR);
         blockBlacklist.add(AliensVsPredator.blocks().resin);
         blockBlacklist.add(AliensVsPredator.blocks().naturalResin);
-        
-
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMatriarch.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMatriarch.java
@@ -64,7 +64,6 @@ public class EntityMatriarch extends SpeciesXenomorph implements IMob
         this.hurtResistantTime = 0;
         this.ignoreFrustumCheck = true;
         this.jellyLimitOverride = true;
-        this.addStandardXenomorphAISet();
     }
 
     public float getOvipositorSize()

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMyceliomorph.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityMyceliomorph.java
@@ -13,7 +13,6 @@ public class EntityMyceliomorph extends SpeciesXenomorph
     public EntityMyceliomorph(World world)
     {
         super(world);
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityNauticomorph.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityNauticomorph.java
@@ -38,8 +38,6 @@ public class EntityNauticomorph extends SpeciesXenomorph
         this.jumpMovementFactor = 0.2F;
         this.experienceValue = 100;
         this.setSize(0.8F, 1.8F);
-        this.tasks.addTask(0, new EntityAISwimming(this));
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityPantheramorph.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityPantheramorph.java
@@ -13,7 +13,6 @@ public class EntityPantheramorph extends SpeciesXenomorph
     public EntityPantheramorph(World world)
     {
         super(world);
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityPraetorian.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityPraetorian.java
@@ -21,11 +21,6 @@ public class EntityPraetorian extends SpeciesXenomorph implements IMaturable
         super(world);
         this.experienceValue = 300;
         this.setSize(1.0F, 3.0F);
-        
-        
-        this.tasks.addTask(0, new EntityAISwimming(this));
-        
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityPredalien.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityPredalien.java
@@ -23,7 +23,6 @@ public class EntityPredalien extends SpeciesXenomorph implements IMob
         this.experienceValue = 225;
         this.setSize(1.0F, 2.5F);
         this.ignoreFrustumCheck = true;
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityRunnerDrone.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityRunnerDrone.java
@@ -14,7 +14,6 @@ public class EntityRunnerDrone extends EntityDrone implements IMaturable
     public EntityRunnerDrone(World world)
     {
         super(world);
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityRunnerWarrior.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityRunnerWarrior.java
@@ -14,7 +14,6 @@ public class EntityRunnerWarrior extends EntityWarrior implements IMaturable
     public EntityRunnerWarrior(World world)
     {
         super(world);
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntitySpitter.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntitySpitter.java
@@ -31,11 +31,12 @@ public class EntitySpitter extends SpeciesXenomorph implements IRangedAttackMob
         super(par1World);
         this.experienceValue = 275;
         this.setSize(1.0F, 3.0F);
-        
-        
-        this.tasks.addTask(0, new EntityAISwimming(this));
+    }
+    
+    @Override
+    protected void addStandardXenomorphAISet() {
         this.tasks.addTask(1, rangedAttackAI);
-        this.addStandardXenomorphAISet();
+    	super.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/EntityWarrior.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/EntityWarrior.java
@@ -23,7 +23,6 @@ public class EntityWarrior extends SpeciesXenomorph implements IMob, IMaturable
         this.experienceValue = 175;
         this.setSize(1.0F, 2.5F);
         this.tasks.addTask(0, new EntityAISwimming(this));
-        this.addStandardXenomorphAISet();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/parasites/EntityFacehugger.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/parasites/EntityFacehugger.java
@@ -32,8 +32,6 @@ public class EntityFacehugger extends EntityParasitoid implements IMob, IParasit
         this.setSize(0.8F, 0.8F);
         this.experienceValue = 10;
         this.jumpMovementFactor = 0.3F;
-        
-        this.addTasks();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/species/xenomorphs/parasites/EntityRoyalFacehugger.java
+++ b/src/main/java/org/avp/entities/living/species/xenomorphs/parasites/EntityRoyalFacehugger.java
@@ -19,7 +19,6 @@ public class EntityRoyalFacehugger extends EntityFacehugger
         super(world);
         this.setSize(1F, 1F);
         this.experienceValue = 300;
-        this.addTasks();
     }
 
     @Override

--- a/src/main/java/org/avp/entities/living/vardic/EntityOctohugger.java
+++ b/src/main/java/org/avp/entities/living/vardic/EntityOctohugger.java
@@ -49,8 +49,6 @@ public class EntityOctohugger extends EntityParasitoid implements IMob, IParasit
         this.experienceValue = 10;
         this.ignoreFrustumCheck = true;
         this.jumpMovementFactor = 0.3F;
-
-        this.addTasks();
     }
 
     @Override


### PR DESCRIPTION
This PR cleans up some unnecessary AI init calls across the alien classes. The previous code may have been adding duplicate AI tasks to all aliens. If those duplicate tasks were executing (likely, as they share the same mutex bit with themselves), then this will cause less execution per alien per tick, increasing performance as well as reducing contention between AI tasks (i.e an alien having two wander tasks, both tasks may select different wander positions and cause unexpected behavior/movement for the alien).